### PR TITLE
[TM-803] Allow local dev environments to customize the next image domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,7 @@ const nextConfig = {
   publicRuntimeConfig: {
     TxNativePublicToken: process.env.TRANSIFEX_TOKEN
   },
-  images: { domains: ["s3-eu-west-1.amazonaws.com"] },
+  images: { domains: process.env.IMAGE_DOMAINS?.split(',') ?? ["s3-eu-west-1.amazonaws.com"] },
   // webpack5: true,
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
This isn't strictly related to TM-803, but was a nice local dev enhancement I added while testing it. This allows local environments to get image uploads working by adding this to their `.env`:
```
IMAGE_DOMAINS = 'localhost'
```