### PR TITLE
[TM-878] Disallow workdays negative amounts

### DIFF
--- a/src/components/extensive/WorkdayCollapseGrid/WorkdayRow.tsx
+++ b/src/components/extensive/WorkdayCollapseGrid/WorkdayRow.tsx
@@ -30,7 +30,7 @@ const WorkdayRow = ({ type, subtypes, label, userLabel, amount, onChange, onDele
         currentTarget: { value }
       } = event;
       const newAmount = Number(value);
-      if (!isNaN(newAmount)) {
+      if (!isNaN(newAmount) && newAmount >= 0) {
         onChange?.(newAmount, userLabel);
       }
     },


### PR DESCRIPTION
A small update to the work for https://gfw.atlassian.net/browse/TM-878 to prevent negative amounts being input with the number input field up/down toggles.