### PR TITLE
Add gallery maps

### DIFF
--- a/src/admin/components/ResourceTabs/PolygonReviewTab/index.tsx
+++ b/src/admin/components/ResourceTabs/PolygonReviewTab/index.tsx
@@ -544,7 +544,7 @@ const PolygonReviewTab: FC<IProps> = props => {
                 showPopups
                 showLegend
                 mapFunctions={mapFunctions}
-                TooltipType="edit"
+                tooltipType="edit"
                 sitePolygonData={sitePolygonData}
               />
               <div className="mb-6">

--- a/src/admin/components/ResourceTabs/PolygonReviewTab/index.tsx
+++ b/src/admin/components/ResourceTabs/PolygonReviewTab/index.tsx
@@ -555,6 +555,8 @@ const PolygonReviewTab: FC<IProps> = props => {
                 showPopups
                 showLegend
                 mapFunctions={mapFunctions}
+                TooltipType="edit"
+                sitePolygonData={sitePolygonData}
               />
               <div className="mb-6">
                 <div className="mb-4">

--- a/src/admin/components/ResourceTabs/PolygonReviewTab/index.tsx
+++ b/src/admin/components/ResourceTabs/PolygonReviewTab/index.tsx
@@ -6,9 +6,10 @@ import { TabbedShowLayout, TabProps, useShowContext } from "react-admin";
 
 import Button from "@/components/elements/Button/Button";
 import { VARIANT_FILE_INPUT_MODAL_ADD_IMAGES } from "@/components/elements/Inputs/FileInput/FileInputVariants";
+import { BBox } from "@/components/elements/Map-mapbox/GeoJSON";
 import { useMap } from "@/components/elements/Map-mapbox/hooks/useMap";
 import { MapContainer } from "@/components/elements/Map-mapbox/Map";
-import { addSourcesToLayers } from "@/components/elements/Map-mapbox/utils";
+import { addSourcesToLayers, mapPolygonData } from "@/components/elements/Map-mapbox/utils";
 import Menu from "@/components/elements/Menu/Menu";
 import { MENU_PLACEMENT_RIGHT_BOTTOM, MENU_PLACEMENT_RIGHT_TOP } from "@/components/elements/Menu/MenuVariant";
 import Table from "@/components/elements/Table/Table";
@@ -124,9 +125,7 @@ const PolygonReviewTab: FC<IProps> = props => {
 
   const mapFunctions = useMap(storePolygon);
 
-  const { data: sitePolygonData, refetch } = useGetV2SitesSitePolygon<{
-    data: SitePolygonsDataResponse;
-  }>({
+  const { data: sitePolygonData, refetch } = useGetV2SitesSitePolygon<SitePolygonsDataResponse>({
     pathParams: {
       site: record.uuid
     }
@@ -138,36 +137,26 @@ const PolygonReviewTab: FC<IProps> = props => {
     }
   });
 
-  const siteBbox = sitePolygonBbox?.bbox;
-  const sitePolygonDataTable = ((sitePolygonData ?? []) as SitePolygonsDataResponse).map(
-    (data: SitePolygon, index) => ({
-      "polygon-name": data.poly_name || `Unnamed Polygon`,
-      "restoration-practice": data.practice,
-      "target-land-use-system": data.target_sys,
-      "tree-distribution": data.distr,
-      "planting-start-date": data.plantstart,
-      source: data.org_name,
-      uuid: data.poly_id,
-      ellipse: index === ((sitePolygonData ?? []) as SitePolygon[]).length - 1
-    })
-  );
+  const siteBbox = sitePolygonBbox?.bbox as BBox;
+  const sitePolygonDataTable = (sitePolygonData ?? []).map((data: SitePolygon, index) => ({
+    "polygon-name": data.poly_name || `Unnamed Polygon`,
+    "restoration-practice": data.practice,
+    "target-land-use-system": data.target_sys,
+    "tree-distribution": data.distr,
+    "planting-start-date": data.plantstart,
+    source: data.org_name,
+    uuid: data.poly_id,
+    ellipse: index === ((sitePolygonData ?? []) as SitePolygon[]).length - 1
+  }));
 
-  const transformedSiteDataForList = ((sitePolygonData ?? []) as SitePolygonsDataResponse).map(
-    (data: SitePolygon, index: number) => ({
-      id: (index + 1).toString(),
-      status: data.status,
-      label: data.poly_name || `Unnamed Polygon`,
-      uuid: data.poly_id
-    })
-  );
+  const transformedSiteDataForList = (sitePolygonData ?? []).map((data: SitePolygon, index: number) => ({
+    id: (index + 1).toString(),
+    status: data.status,
+    label: data.poly_name || `Unnamed Polygon`,
+    uuid: data.poly_id
+  }));
 
-  const polygonDataMap = ((sitePolygonData ?? []) as SitePolygonsDataResponse).reduce((acc: any, data: any) => {
-    if (!acc[data.status]) {
-      acc[data.status] = [];
-    }
-    acc[data.status].push(data.poly_id);
-    return acc;
-  }, {});
+  const polygonDataMap = mapPolygonData(sitePolygonData);
 
   const { openModal, closeModal } = useModalContext();
 

--- a/src/components/elements/Map-mapbox/Map.d.ts
+++ b/src/components/elements/Map-mapbox/Map.d.ts
@@ -8,3 +8,5 @@ export interface LayerType {
 }
 
 export type ControlType = Control | IControl;
+
+export type TooltipType = "edit" | "goTo" | "view";

--- a/src/components/elements/Map-mapbox/Map.tsx
+++ b/src/components/elements/Map-mapbox/Map.tsx
@@ -79,7 +79,7 @@ interface MapProps extends Omit<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>
   showPopups?: boolean;
   showLegend?: boolean;
   mapFunctions?: any;
-  TooltipType?: TooltipType;
+  tooltipType?: TooltipType;
   sitePolygonData?: SitePolygonsDataResponse;
 }
 
@@ -104,7 +104,7 @@ export const MapContainer = ({
   showPopups = false,
   showLegend = false,
   mapFunctions,
-  TooltipType = "view",
+  tooltipType = "view",
   ...props
 }: MapProps) => {
   const [viewImages, setViewImages] = useState(false);
@@ -147,7 +147,7 @@ export const MapContainer = ({
       const currentMap = map.current;
 
       map.current.on("load", () => {
-        addPopupsToMap(currentMap, AdminPopup, setPolygonFromMap, sitePolygonData, TooltipType);
+        addPopupsToMap(currentMap, AdminPopup, setPolygonFromMap, sitePolygonData, tooltipType);
       });
     }
   }, [styleLoaded, sitePolygonData]);

--- a/src/components/elements/Map-mapbox/Map.tsx
+++ b/src/components/elements/Map-mapbox/Map.tsx
@@ -15,11 +15,12 @@ import ControlGroup from "@/components/elements/Map-mapbox/components/ControlGro
 import { AdditionalPolygonProperties } from "@/components/elements/Map-mapbox/MapLayers/ShapePropertiesModal";
 import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import { LAYERS_NAMES, layersList } from "@/constants/layers";
-import { SitePolygonData, useSitePolygonData } from "@/context/sitePolygon.provider";
+import { useSitePolygonData } from "@/context/sitePolygon.provider";
 import { fetchGetV2TerrafundPolygonGeojsonUuid, fetchPutV2TerrafundPolygonUuid } from "@/generated/apiComponents";
 import { SitePolygonsDataResponse } from "@/generated/apiSchemas";
 
 import { AdminPopup } from "./components/AdminPopup";
+import { BBox } from "./GeoJSON";
 import type { TooltipType } from "./Map.d";
 import CheckPolygonControl from "./MapControls/CheckPolygonControl";
 import EditControl from "./MapControls/EditControl";
@@ -68,8 +69,8 @@ interface MapProps extends Omit<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>
   polygonChecks?: boolean;
   legend?: LegendItem[];
   centroids?: any;
-  polygonsData?: SitePolygonsDataResponse;
-  bbox?: any;
+  polygonsData?: Record<string, string[]>;
+  bbox?: BBox;
   setPolygonFromMap?: React.Dispatch<React.SetStateAction<{ uuid: string; isOpen: boolean }>>;
   polygonFromMap?: { uuid: string; isOpen: boolean };
   record?: any;
@@ -79,7 +80,7 @@ interface MapProps extends Omit<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>
   showLegend?: boolean;
   mapFunctions?: any;
   TooltipType?: TooltipType;
-  sitePolygonData?: SitePolygonData;
+  sitePolygonData?: SitePolygonsDataResponse;
 }
 
 export const MapContainer = ({

--- a/src/components/elements/Map-mapbox/Map.tsx
+++ b/src/components/elements/Map-mapbox/Map.tsx
@@ -15,11 +15,12 @@ import ControlGroup from "@/components/elements/Map-mapbox/components/ControlGro
 import { AdditionalPolygonProperties } from "@/components/elements/Map-mapbox/MapLayers/ShapePropertiesModal";
 import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import { LAYERS_NAMES, layersList } from "@/constants/layers";
-import { useSitePolygonData } from "@/context/sitePolygon.provider";
+import { SitePolygonData, useSitePolygonData } from "@/context/sitePolygon.provider";
 import { fetchGetV2TerrafundPolygonGeojsonUuid, fetchPutV2TerrafundPolygonUuid } from "@/generated/apiComponents";
 import { SitePolygonsDataResponse } from "@/generated/apiSchemas";
 
 import { AdminPopup } from "./components/AdminPopup";
+import type { TooltipType } from "./Map.d";
 import CheckPolygonControl from "./MapControls/CheckPolygonControl";
 import EditControl from "./MapControls/EditControl";
 import { FilterControl } from "./MapControls/FilterControl";
@@ -77,6 +78,8 @@ interface MapProps extends Omit<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>
   showPopups?: boolean;
   showLegend?: boolean;
   mapFunctions?: any;
+  TooltipType?: TooltipType;
+  sitePolygonData?: SitePolygonData;
 }
 
 export const MapContainer = ({
@@ -100,13 +103,13 @@ export const MapContainer = ({
   showPopups = false,
   showLegend = false,
   mapFunctions,
+  TooltipType = "view",
   ...props
 }: MapProps) => {
   const [viewImages, setViewImages] = useState(false);
   const [currentStyle, setCurrentStyle] = useState(MapStyle.Satellite);
-  const { polygonsData, bbox, setPolygonFromMap, polygonFromMap } = props;
+  const { polygonsData, bbox, setPolygonFromMap, polygonFromMap, sitePolygonData } = props;
   const context = useSitePolygonData();
-  const sitePolygonData = context?.sitePolygonData;
   const { isUserDrawingEnabled } = isUserDrawing
     ? { isUserDrawingEnabled: isUserDrawing }
     : context || { isUserDrawingEnabled: false };
@@ -143,7 +146,7 @@ export const MapContainer = ({
       const currentMap = map.current;
 
       map.current.on("load", () => {
-        addPopupsToMap(currentMap, AdminPopup, setPolygonFromMap, sitePolygonData);
+        addPopupsToMap(currentMap, AdminPopup, setPolygonFromMap, sitePolygonData, TooltipType);
       });
     }
   }, [styleLoaded, sitePolygonData]);

--- a/src/components/elements/Map-mapbox/components/AdminPopup.tsx
+++ b/src/components/elements/Map-mapbox/components/AdminPopup.tsx
@@ -5,12 +5,13 @@ import TooltipMap from "../../TooltipMap/TooltipMap";
 const client = new QueryClient();
 
 export const AdminPopup = (event: any) => {
-  const { feature, popup, setPolygonFromMap } = event;
+  const { feature, popup, setPolygonFromMap, type } = event;
   const uuidPolygon = feature.properties?.uuid;
   return (
     <QueryClientProvider client={client}>
       <TooltipMap
         polygon={uuidPolygon}
+        type={type}
         setTooltipOpen={() => {
           if (popup) {
             popup.remove();

--- a/src/components/elements/Map-mapbox/utils.ts
+++ b/src/components/elements/Map-mapbox/utils.ts
@@ -4,8 +4,7 @@ import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
 import { layersList } from "@/constants/layers";
-import { SitePolygonData } from "@/context/sitePolygon.provider";
-import { SitePolygonsDataResponse } from "@/generated/apiSchemas";
+import { SitePolygon, SitePolygonsDataResponse } from "@/generated/apiSchemas";
 
 import { BBox, FeatureCollection } from "./GeoJSON";
 import type { LayerType, LayerWithStyle, TooltipType } from "./Map.d";
@@ -67,7 +66,7 @@ export const stopDrawing = (draw: MapboxDraw, map: mapboxgl.Map) => {
 export const addFilterOnLayer = (
   layer: any,
   field: string,
-  parsedPolygonData: SitePolygonsDataResponse,
+  parsedPolygonData: Record<string, string[]>,
   map: mapboxgl.Map
 ) => {
   addSourceToLayer(layer, map, parsedPolygonData);
@@ -103,7 +102,7 @@ const showPolygons = (
 let popup: mapboxgl.Popup | null = null;
 let arrayPopups: mapboxgl.Popup[] = [];
 
-export const loadLayersInMap = (map: mapboxgl.Map, polygonsData: SitePolygonsDataResponse | undefined) => {
+export const loadLayersInMap = (map: mapboxgl.Map, polygonsData: Record<string, string[]> | undefined) => {
   layersList.forEach((layer: any) => {
     if (map) {
       showPolygons(layer.styles, layer.name, map, "uuid", polygonsData);
@@ -116,7 +115,7 @@ const handleLayerClick = (
   popupComponent: any,
   map: mapboxgl.Map,
   setPolygonFromMap: any,
-  sitePolygonData: SitePolygonData | undefined,
+  sitePolygonData: SitePolygonsDataResponse | undefined,
   type: TooltipType
 ) => {
   removePopups();
@@ -139,7 +138,7 @@ export const removePopups = () => {
   });
 };
 
-export const addFilterOfPolygonsData = (map: mapboxgl.Map, polygonsData: SitePolygonsDataResponse | undefined) => {
+export const addFilterOfPolygonsData = (map: mapboxgl.Map, polygonsData: Record<string, string[]> | undefined) => {
   if (map && polygonsData) {
     if (map.isStyleLoaded() || map.loaded()) {
       loadLayersInMap(map, polygonsData);
@@ -170,7 +169,7 @@ export const addGeojsonToDraw = (geojson: any, uuid: string, cb: Function, curre
   }
 };
 
-export const addSourcesToLayers = (map: mapboxgl.Map, polygonsData: SitePolygonsDataResponse | undefined) => {
+export const addSourcesToLayers = (map: mapboxgl.Map, polygonsData: Record<string, string[]> | undefined) => {
   layersList.forEach((layer: LayerType) => {
     if (map) {
       addSourceToLayer(layer, map, polygonsData);
@@ -182,7 +181,7 @@ export const addPopupsToMap = (
   map: mapboxgl.Map,
   popupComponent: any,
   setPolygonFromMap: any,
-  sitePolygonData: SitePolygonData | undefined,
+  sitePolygonData: SitePolygonsDataResponse | undefined,
   type: TooltipType
 ) => {
   if (popupComponent) {
@@ -197,7 +196,7 @@ export const addPopupToLayer = (
   popupComponent: any,
   layer: any,
   setPolygonFromMap: any,
-  sitePolygonData: SitePolygonData | undefined,
+  sitePolygonData: SitePolygonsDataResponse | undefined,
   type: TooltipType
 ) => {
   if (popupComponent) {
@@ -215,7 +214,7 @@ export const addPopupToLayer = (
   }
 };
 
-export const addSourceToLayer = (layer: any, map: mapboxgl.Map, polygonsData: SitePolygonsDataResponse | undefined) => {
+export const addSourceToLayer = (layer: any, map: mapboxgl.Map, polygonsData: Record<string, string[]> | undefined) => {
   const { name, styles } = layer;
   if (map.getSource(name)) {
     styles?.forEach((_: unknown, index: number) => {
@@ -264,3 +263,15 @@ export const formatPlannedStartDate = (plantStartDate: Date | null | undefined):
       })
     : "Unknown";
 };
+
+export function mapPolygonData(sitePolygonData: SitePolygonsDataResponse | undefined) {
+  return (sitePolygonData ?? []).reduce((acc: Record<string, string[]>, data: SitePolygon) => {
+    if (data.status && data.poly_id !== undefined) {
+      if (!acc[data.status]) {
+        acc[data.status] = [];
+      }
+      acc[data.status].push(data.poly_id);
+    }
+    return acc;
+  }, {});
+}

--- a/src/components/elements/Map-mapbox/utils.ts
+++ b/src/components/elements/Map-mapbox/utils.ts
@@ -8,7 +8,7 @@ import { SitePolygonData } from "@/context/sitePolygon.provider";
 import { SitePolygonsDataResponse } from "@/generated/apiSchemas";
 
 import { BBox, FeatureCollection } from "./GeoJSON";
-import type { LayerType, LayerWithStyle } from "./Map.d";
+import type { LayerType, LayerWithStyle, TooltipType } from "./Map.d";
 
 const GEOSERVER = "https://geoserver-prod.wri-restoration-marketplace-api.com";
 
@@ -116,7 +116,8 @@ const handleLayerClick = (
   popupComponent: any,
   map: mapboxgl.Map,
   setPolygonFromMap: any,
-  sitePolygonData: SitePolygonData | undefined
+  sitePolygonData: SitePolygonData | undefined,
+  type: TooltipType
 ) => {
   removePopups();
   const { lng, lat } = e.lngLat;
@@ -125,7 +126,7 @@ const handleLayerClick = (
   let popupContent = document.createElement("div");
   popupContent.className = "popup-content-map";
   const root = createRoot(popupContent);
-  root.render(createElement(popupComponent, { feature, popup, setPolygonFromMap, sitePolygonData }));
+  root.render(createElement(popupComponent, { feature, popup, setPolygonFromMap, sitePolygonData, type }));
 
   popup = new mapboxgl.Popup({ className: "popup-map" }).setLngLat([lng, lat]).setDOMContent(popupContent).addTo(map);
 
@@ -181,11 +182,12 @@ export const addPopupsToMap = (
   map: mapboxgl.Map,
   popupComponent: any,
   setPolygonFromMap: any,
-  sitePolygonData: SitePolygonData | undefined
+  sitePolygonData: SitePolygonData | undefined,
+  type: TooltipType
 ) => {
   if (popupComponent) {
     layersList.forEach((layer: LayerType) => {
-      addPopupToLayer(map, popupComponent, layer, setPolygonFromMap, sitePolygonData);
+      addPopupToLayer(map, popupComponent, layer, setPolygonFromMap, sitePolygonData, type);
     });
   }
 };
@@ -195,7 +197,8 @@ export const addPopupToLayer = (
   popupComponent: any,
   layer: any,
   setPolygonFromMap: any,
-  sitePolygonData: SitePolygonData | undefined
+  sitePolygonData: SitePolygonData | undefined,
+  type: TooltipType
 ) => {
   if (popupComponent) {
     const { name } = layer;
@@ -206,7 +209,7 @@ export const addPopupToLayer = (
 
     targetLayers.forEach(targetLayer => {
       map.on("click", targetLayer.id, (e: any) =>
-        handleLayerClick(e, popupComponent, map, setPolygonFromMap, sitePolygonData)
+        handleLayerClick(e, popupComponent, map, setPolygonFromMap, sitePolygonData, type)
       );
     });
   }

--- a/src/components/elements/TooltipMap/TooltipMap.tsx
+++ b/src/components/elements/TooltipMap/TooltipMap.tsx
@@ -4,12 +4,14 @@ import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import { useGetV2TerrafundPolygonUuid } from "@/generated/apiComponents";
 import { SitePolygon } from "@/generated/apiSchemas";
 
+import type { TooltipType } from "../Map-mapbox/Map.d";
 import { formatPlannedStartDate } from "../Map-mapbox/utils";
 import Text from "../Text/Text";
 export interface TooltipMapProps {
   setTooltipOpen: () => void;
   setEditPolygon: () => void;
   polygon: any;
+  type?: TooltipType;
   popup?: any;
 }
 const topBorderColorPopup: any = {
@@ -20,7 +22,7 @@ const topBorderColorPopup: any = {
 };
 
 const TooltipMap = (props: TooltipMapProps) => {
-  const { setTooltipOpen, setEditPolygon, polygon } = props;
+  const { setTooltipOpen, setEditPolygon, polygon, type } = props;
   const [polygonData, setPolygonData] = React.useState<SitePolygon>();
   const { data: sitePolygonData } = useGetV2TerrafundPolygonUuid<{
     site_polygon: SitePolygon;
@@ -95,14 +97,16 @@ const TooltipMap = (props: TooltipMapProps) => {
       </div>
 
       <hr className="my-2 border border-grey-750" />
-      <div className="flex w-full items-center justify-center">
-        <button className="flex items-center justify-center gap-1" onClick={setEditPolygon}>
-          <Icon name={IconNames.CLICK} className="h-4 w-4" />
-          <Text variant="text-10-light" className="italic text-black">
-            click to see polygon details
-          </Text>
-        </button>
-      </div>
+      {type === "edit" && (
+        <div className="flex w-full items-center justify-center">
+          <button className="flex items-center justify-center gap-1" onClick={setEditPolygon}>
+            <Icon name={IconNames.CLICK} className="h-4 w-4" />
+            <Text variant="text-10-light" className="italic text-black">
+              click to see polygon details
+            </Text>
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/context/sitePolygon.provider.tsx
+++ b/src/context/sitePolygon.provider.tsx
@@ -7,7 +7,7 @@ export type SitePolygonData = {
 };
 
 type SitePolygonContextType = {
-  sitePolygonData: SitePolygonData | undefined;
+  sitePolygonData: SitePolygonsDataResponse | undefined;
   reloadSiteData: () => void;
   isUserDrawingEnabled: boolean;
   toggleUserDrawing: (arg0: boolean) => void;
@@ -18,13 +18,13 @@ type SitePolygonContextType = {
 const SitePolygonDataContext = createContext<SitePolygonContextType | undefined>(undefined);
 
 export const SitePolygonDataProvider: React.FC<{
-  sitePolygonData: SitePolygonData | undefined;
+  sitePolygonData: SitePolygonsDataResponse | undefined;
   reloadSiteData: () => void;
   children: ReactNode;
 }> = ({ sitePolygonData, reloadSiteData, children }) => {
   const [isUserDrawingEnabled, setIsUserDrawingEnabled] = useState<boolean>(false);
   type SitePolygonContextType = {
-    sitePolygonData: SitePolygonData | undefined;
+    sitePolygonData: SitePolygonsDataResponse | undefined;
     reloadSiteData: () => void;
     isUserDrawingEnabled: boolean;
     toggleUserDrawing: (arg0: boolean) => void;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently, the gallery for projects and sites does not display any map or location data.


## What is the new behavior?

A new map component or section has been added to the gallery page for projects and sites.
- This map will display the geographic locations of the various projects and sites featured in the gallery.
- Users can now visually see where each project or site is located on the map, providing additional context and information.
- The map include markers and polygons.
- Clicking on a specific location marker provides more details about that particular polygon
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
