### PR TITLE
feat: add status diagram on site and project profile

### DIFF
--- a/src/hooks/AuditStatus/useAuditLogActions.ts
+++ b/src/hooks/AuditStatus/useAuditLogActions.ts
@@ -29,7 +29,7 @@ const ReverseButtonStates2: { [key: number]: string } = {
   2: "site-polygon"
 };
 
-const statusActionsMap = {
+export const statusActionsMap = {
   [AuditLogButtonStates.PROJECT as number]: {
     mutateEntity: fetchPutV2ENTITYUUIDStatus,
     valuesForStatus: getValueForStatusProject,

--- a/src/pages/project/[uuid]/tabs/Overview.tsx
+++ b/src/pages/project/[uuid]/tabs/Overview.tsx
@@ -3,20 +3,17 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Else, If, Then } from "react-if";
 
-import { AuditLogButtonStates } from "@/admin/components/ResourceTabs/AuditLogTab/constants/enum";
 import Button from "@/components/elements/Button/Button";
 import GoalProgressCard from "@/components/elements/Cards/GoalProgressCard/GoalProgressCard";
 import ItemMonitoringCards from "@/components/elements/Cards/ItemMonitoringCard/ItemMonitoringCards";
 import Dropdown from "@/components/elements/Inputs/Dropdown/Dropdown";
 import OverviewMapArea from "@/components/elements/Map-mapbox/components/OverviewMapArea";
-import StepProgressbar from "@/components/elements/ProgressBar/StepProgressbar/StepProgressbar";
 import Text from "@/components/elements/Text/Text";
 import { IconNames } from "@/components/extensive/Icon/Icon";
 import PageBody from "@/components/extensive/PageElements/Body/PageBody";
 import PageCard from "@/components/extensive/PageElements/Card/PageCard";
 import PageColumn from "@/components/extensive/PageElements/Column/PageColumn";
 import PageRow from "@/components/extensive/PageElements/Row/PageRow";
-import { statusActionsMap } from "@/hooks/AuditStatus/useAuditLogActions";
 import { useFramework } from "@/hooks/useFramework";
 
 interface ProjectOverviewTabProps {
@@ -27,7 +24,7 @@ const ProjectOverviewTab = ({ project }: ProjectOverviewTabProps) => {
   const t = useT();
   const router = useRouter();
   const { isPPC } = useFramework(project);
-  const { valuesForStatus, statusLabels } = statusActionsMap[AuditLogButtonStates.SITE];
+
   return (
     <PageBody>
       <PageRow>
@@ -100,15 +97,6 @@ const ProjectOverviewTab = ({ project }: ProjectOverviewTabProps) => {
               </Button>
             }
           >
-            <div className="w-[46%] p-10">
-              <StepProgressbar
-                color="secondary"
-                value={valuesForStatus?.(project?.status) ?? 0}
-                labels={statusLabels}
-                classNameLabels="min-w-[99px]"
-                className={"w-[98%] pl-[1%]"}
-              />
-            </div>
             <OverviewMapArea entityModel={project} type="projects" />
           </PageCard>
         </PageColumn>

--- a/src/pages/project/[uuid]/tabs/Overview.tsx
+++ b/src/pages/project/[uuid]/tabs/Overview.tsx
@@ -3,17 +3,20 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Else, If, Then } from "react-if";
 
+import { AuditLogButtonStates } from "@/admin/components/ResourceTabs/AuditLogTab/constants/enum";
 import Button from "@/components/elements/Button/Button";
 import GoalProgressCard from "@/components/elements/Cards/GoalProgressCard/GoalProgressCard";
 import ItemMonitoringCards from "@/components/elements/Cards/ItemMonitoringCard/ItemMonitoringCards";
 import Dropdown from "@/components/elements/Inputs/Dropdown/Dropdown";
 import OverviewMapArea from "@/components/elements/Map-mapbox/components/OverviewMapArea";
+import StepProgressbar from "@/components/elements/ProgressBar/StepProgressbar/StepProgressbar";
 import Text from "@/components/elements/Text/Text";
 import { IconNames } from "@/components/extensive/Icon/Icon";
 import PageBody from "@/components/extensive/PageElements/Body/PageBody";
 import PageCard from "@/components/extensive/PageElements/Card/PageCard";
 import PageColumn from "@/components/extensive/PageElements/Column/PageColumn";
 import PageRow from "@/components/extensive/PageElements/Row/PageRow";
+import { statusActionsMap } from "@/hooks/AuditStatus/useAuditLogActions";
 import { useFramework } from "@/hooks/useFramework";
 
 interface ProjectOverviewTabProps {
@@ -24,7 +27,7 @@ const ProjectOverviewTab = ({ project }: ProjectOverviewTabProps) => {
   const t = useT();
   const router = useRouter();
   const { isPPC } = useFramework(project);
-
+  const { valuesForStatus, statusLabels } = statusActionsMap[AuditLogButtonStates.SITE];
   return (
     <PageBody>
       <PageRow>
@@ -97,6 +100,15 @@ const ProjectOverviewTab = ({ project }: ProjectOverviewTabProps) => {
               </Button>
             }
           >
+            <div className="w-[46%] p-10">
+              <StepProgressbar
+                color="secondary"
+                value={valuesForStatus?.(project?.status) ?? 0}
+                labels={statusLabels}
+                classNameLabels="min-w-[99px]"
+                className={"w-[98%] pl-[1%]"}
+              />
+            </div>
             <OverviewMapArea entityModel={project} type="projects" />
           </PageCard>
         </PageColumn>

--- a/src/pages/site/[uuid]/tabs/Overview.tsx
+++ b/src/pages/site/[uuid]/tabs/Overview.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { When } from "react-if";
 
+import { AuditLogButtonStates } from "@/admin/components/ResourceTabs/AuditLogTab/constants/enum";
 import AddDataButton from "@/admin/components/ResourceTabs/PolygonReviewTab/components/AddDataButton";
 import Button from "@/components/elements/Button/Button";
 import GoalProgressCard from "@/components/elements/Cards/GoalProgressCard/GoalProgressCard";
@@ -13,6 +14,7 @@ import { VARIANT_FILE_INPUT_MODAL_ADD_IMAGES } from "@/components/elements/Input
 import { downloadSiteGeoJsonPolygons } from "@/components/elements/Map-mapbox/utils";
 import Menu from "@/components/elements/Menu/Menu";
 import { MENU_PLACEMENT_BOTTOM_BOTTOM } from "@/components/elements/Menu/MenuVariant";
+import StepProgressbar from "@/components/elements/ProgressBar/StepProgressbar/StepProgressbar";
 import Text from "@/components/elements/Text/Text";
 import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import ModalAdd from "@/components/extensive/Modal/ModalAdd";
@@ -31,6 +33,7 @@ import {
 } from "@/generated/apiComponents";
 import { SitePolygonsDataResponse } from "@/generated/apiSchemas";
 import { getEntityDetailPageLink } from "@/helpers/entity";
+import { statusActionsMap } from "@/hooks/AuditStatus/useAuditLogActions";
 import { useFramework } from "@/hooks/useFramework";
 import { FileType, UploadedFile } from "@/types/common";
 
@@ -172,6 +175,8 @@ const SiteOverviewTab = ({ site }: SiteOverviewTabProps) => {
     }
   ];
 
+  const { valuesForStatus, statusLabels } = statusActionsMap[AuditLogButtonStates.SITE];
+
   return (
     <SitePolygonDataProvider sitePolygonData={sitePolygonData} reloadSiteData={refetch}>
       <PageBody>
@@ -251,6 +256,15 @@ const SiteOverviewTab = ({ site }: SiteOverviewTabProps) => {
                       </Menu>
                     )}
                   </div>
+                </div>
+                <div className="w-[46%]">
+                  <StepProgressbar
+                    color="secondary"
+                    value={valuesForStatus?.(site?.status) ?? 0}
+                    labels={statusLabels}
+                    classNameLabels="min-w-[99px]"
+                    className={"w-[98%] pl-[1%]"}
+                  />
                 </div>
               </div>
               <SiteArea sites={site} setEditPolygon={setEditPolygon} editPolygon={editPolygon} />


### PR DESCRIPTION
There is not task related, just some requirement to display the status diagram on site profile.
<img width="1281" alt="image" src="https://github.com/wri/wri-terramatch-website/assets/26514574/748bd60e-4907-4d04-b81c-90c178dfb24b">
