### PR TITLE
[TM-1137] Better null handling for old report update requests.

### DIFF
--- a/src/components/elements/Inputs/WorkdaysInput/RHFWorkdaysTable.tsx
+++ b/src/components/elements/Inputs/WorkdaysInput/RHFWorkdaysTable.tsx
@@ -29,14 +29,7 @@ const RHFWorkdaysTable = ({
     field: { value, onChange }
   } = useController(props);
 
-  const demographics = useMemo(
-    function () {
-      if (value == null || value.length == 0) {
-        return [];
-      } else return value[0].demographics;
-    },
-    [value]
-  );
+  const demographics = useMemo(() => value?.[0]?.demographics ?? [], [value]);
 
   const updateDemographics = useCallback(
     (updatedDemographics: Demographic[]) => {


### PR DESCRIPTION
Reports with an active update request from before the transition to the new demographics system have data in an unexpected shape. This null check better handles those cases.

https://gfw.atlassian.net/browse/TM-1137