### PR TITLE
[TM-1415] Provide the framework to getCustomFormSteps when possible.

### DIFF
--- a/src/admin/components/EntityEdit/EntityEdit.tsx
+++ b/src/admin/components/EntityEdit/EntityEdit.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import modules from "@/admin/modules";
 import WizardForm from "@/components/extensive/WizardForm";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
-import FrameworkProvider from "@/context/framework.provider";
+import FrameworkProvider, { Framework } from "@/context/framework.provider";
 import {
   GetV2FormsENTITYUUIDResponse,
   useGetV2FormsENTITYUUID,
@@ -49,10 +49,12 @@ export const EntityEdit = () => {
   // @ts-ignore
   const formData = (formResponse?.data ?? {}) as GetV2FormsENTITYUUIDResponse;
 
-  const formSteps = useGetCustomFormSteps(formData.form, {
+  const entity = {
     entityName: pluralEntityNameToSingular(entityName),
     entityUUID
-  });
+  };
+  const framework = formData?.form?.framework_key as Framework;
+  const formSteps = useGetCustomFormSteps(formData.form, entity, framework);
 
   const defaultValues = useNormalizedFormDefaultValue(
     // @ts-ignore
@@ -70,7 +72,7 @@ export const EntityEdit = () => {
   return (
     <div className="mx-auto w-full max-w-7xl">
       <LoadingContainer loading={isLoading}>
-        <FrameworkProvider frameworkKey={formData?.form?.framework_key}>
+        <FrameworkProvider frameworkKey={framework}>
           <WizardForm
             steps={formSteps!}
             errors={error}

--- a/src/admin/components/ResourceTabs/ChangeRequestsTab/ChangeRequestsTab.tsx
+++ b/src/admin/components/ResourceTabs/ChangeRequestsTab/ChangeRequestsTab.tsx
@@ -17,6 +17,7 @@ import { Else, If, Then, When } from "react-if";
 import ChangeRow from "@/admin/components/ResourceTabs/ChangeRequestsTab/ChangeRow";
 import useFormChanges from "@/admin/components/ResourceTabs/ChangeRequestsTab/useFormChanges";
 import List from "@/components/extensive/List/List";
+import { Framework } from "@/context/framework.provider";
 import { useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
 import { getCustomFormSteps } from "@/helpers/customForms";
 import { EntityName, SingularEntityName } from "@/types/common";
@@ -46,6 +47,7 @@ const ChangeRequestsTab: FC<IProps> = ({ label, entity, singularEntity, ...rest 
 
   // @ts-ignore
   const changeRequest = currentValues?.data?.update_request;
+  const framework = changeRequest?.framework_key as Framework;
   const changes = changeRequest?.content;
   // @ts-ignore
   const current = currentValues?.data?.answers;
@@ -54,7 +56,7 @@ const ChangeRequestsTab: FC<IProps> = ({ label, entity, singularEntity, ...rest 
   // @ts-ignore
   const form = currentValues?.data?.form;
 
-  const formSteps = useMemo(() => (form == null ? [] : getCustomFormSteps(form, t)), [form, t]);
+  const formSteps = useMemo(() => (form == null ? [] : getCustomFormSteps(form, t, undefined, framework)), [form, t]);
   const formChanges = useFormChanges(current, changes, formSteps ?? []);
   const numFieldsAffected = useMemo(
     () =>

--- a/src/admin/components/ResourceTabs/InformationTab/index.tsx
+++ b/src/admin/components/ResourceTabs/InformationTab/index.tsx
@@ -75,7 +75,8 @@ const InformationTab: FC<IProps> = props => {
 
   if (isLoading) return null;
 
-  const formSteps = getCustomFormSteps(response?.data.form!, t);
+  const framework = record.framework_key as Framework;
+  const formSteps = getCustomFormSteps(response?.data.form!, t, undefined, framework);
 
   const values = record.migrated
     ? setDefaultConditionalFieldsAnswers(normalizedFormDefaultValue(response?.data.answers!, formSteps), formSteps)
@@ -101,7 +102,7 @@ const InformationTab: FC<IProps> = props => {
   })();
 
   return (
-    <FrameworkProvider frameworkKey={record.framework_key}>
+    <FrameworkProvider frameworkKey={framework}>
       <When condition={!isLoading}>
         <TabbedShowLayout.Tab label={tabTitle} {...props}>
           <Grid spacing={2} container>

--- a/src/admin/modules/application/components/ApplicationTabs.tsx
+++ b/src/admin/modules/application/components/ApplicationTabs.tsx
@@ -13,6 +13,7 @@ import { Else, If, Then, When } from "react-if";
 import { formatEntryValue } from "@/admin/apiProvider/utils/entryFormat";
 import List from "@/components/extensive/List/List";
 import { FormSummaryRowProps, useGetFormEntries } from "@/components/extensive/WizardForm/FormSummaryRow";
+import { Framework } from "@/context/framework.provider";
 import { ApplicationRead, FormSubmissionRead } from "@/generated/apiSchemas";
 import { getCustomFormSteps, normalizedFormDefaultValue } from "@/helpers/customForms";
 import { Entity } from "@/types/common";
@@ -48,7 +49,8 @@ const ApplicationTabRow = ({ index, ...props }: FormSummaryRowProps) => {
 
 const ApplicationTab = ({ record }: { record: FormSubmissionRead }) => {
   const t = useT();
-  const formSteps = getCustomFormSteps(record?.form!, t);
+  const framework = record?.form?.framework_key as Framework;
+  const formSteps = getCustomFormSteps(record?.form!, t, undefined, framework);
   const values = normalizedFormDefaultValue(record?.answers, formSteps);
   const currentPitchEntity: Entity = {
     entityName: "project-pitches",

--- a/src/hooks/useGetCustomFormSteps/useGetCustomFormSteps.ts
+++ b/src/hooks/useGetCustomFormSteps/useGetCustomFormSteps.ts
@@ -2,6 +2,7 @@ import { useT } from "@transifex/react";
 import { useMemo } from "react";
 
 import { FormStepSchema } from "@/components/extensive/WizardForm/types";
+import { Framework } from "@/context/framework.provider";
 import { FormRead } from "@/generated/apiSchemas";
 import { getCustomFormSteps, normalizedFormDefaultValue } from "@/helpers/customForms";
 import { Entity } from "@/types/common";
@@ -9,12 +10,13 @@ import { Entity } from "@/types/common";
 export const useGetCustomFormSteps = (
   schema?: FormRead,
   entity?: Entity,
+  framework?: Framework,
   feedback_fields?: string[]
 ): FormStepSchema[] | undefined => {
   const t = useT();
 
   return useMemo(
-    () => (schema ? getCustomFormSteps(schema, t, entity, feedback_fields) : undefined),
+    () => (schema ? getCustomFormSteps(schema, t, entity, framework, feedback_fields) : undefined),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [schema, t]
   );

--- a/src/pages/entity/[entityName]/edit/[uuid]/EditEntityForm.tsx
+++ b/src/pages/entity/[entityName]/edit/[uuid]/EditEntityForm.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useMemo } from "react";
 
 import WizardForm from "@/components/extensive/WizardForm";
+import { useFrameworkContext } from "@/context/framework.provider";
 import {
   GetV2FormsENTITYUUIDResponse,
   usePutV2FormsENTITYUUID,
@@ -27,6 +28,7 @@ interface EditEntityFormProps {
 const EditEntityForm = ({ entityName, entityUUID, entity, formData }: EditEntityFormProps) => {
   const t = useT();
   const router = useRouter();
+  const { framework } = useFrameworkContext();
 
   const mode = router.query.mode as string | undefined; //edit, provide-feedback-entity, provide-feedback-change-request
   const isReport = isEntityReport(entityName);
@@ -50,6 +52,7 @@ const EditEntityForm = ({ entityName, entityUUID, entity, formData }: EditEntity
       entityName: pluralEntityNameToSingular(entityName),
       entityUUID
     },
+    framework,
     mode?.includes("provide-feedback") ? feedbackFields : undefined
   );
 


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1415

The problem here is that yesterday I tried to pull `framework_key` off of the `entity` in  `getFieldValidation` because workday validation now depends on knowing what kind of framework we're in. However, `entity` doesn't have `framework_key`, so that fix was invalid. To make matters more complicated, `getFieldValidation` is called in some contexts that are surrounded by a FrameworkContext, and in some that are not. So, we now have to accept `framework` optionally and pass it in when it's available.