### PR TITLE
[TM-1442] Pass all extra props to the input wrapper and avoid adding a second title to the workday grid

### DIFF
--- a/src/components/elements/Inputs/WorkdaysInput/RHFWorkdaysTable.tsx
+++ b/src/components/elements/Inputs/WorkdaysInput/RHFWorkdaysTable.tsx
@@ -54,13 +54,8 @@ const RHFWorkdaysTable = ({
   );
 
   return (
-    <InputWrapper error={props.error}>
-      <WorkdayCollapseGrid
-        title={props.label ?? ""}
-        demographics={demographics}
-        variant={GRID_VARIANT_GREEN}
-        onChange={updateDemographics}
-      />
+    <InputWrapper {...props}>
+      <WorkdayCollapseGrid demographics={demographics} variant={GRID_VARIANT_GREEN} onChange={updateDemographics} />
     </InputWrapper>
   );
 };


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1442

This applies the same fix as the [other PR](https://github.com/wri/wri-terramatch-website/pull/619), this time for hotfix.