### PR TITLE
[TM-572] "Nothing to report" selection bumps user to page 1 of reports

### DIFF
--- a/src/hooks/useDate.ts
+++ b/src/hooks/useDate.ts
@@ -1,7 +1,9 @@
 import { format as _format, subMonths, subWeeks } from "date-fns";
-import * as Locales from "date-fns/locale";
+import * as DateLocales from "date-fns/locale";
 import { useRouter } from "next/router";
+import { useCallback } from "react";
 
+const Locales = DateLocales as Record<string, any>;
 /**
  * Collection of most used date manipulator and formatter.
  * @returns { format, subMonths, subWeeks }
@@ -16,11 +18,14 @@ export const useDate = () => {
    * @param format default: dd/MM/yyyy
    * @returns string
    */
-  const format = (date?: string | number | Date, format = "dd/MM/yyyy") => {
-    if (!date) return "";
-    // @ts-ignore
-    return _format(new Date(date), format, { locale: Locales[formattedLocale] ?? Locales.enUS });
-  };
+  const format = useCallback(
+    (date?: string | number | Date, format = "dd/MM/yyyy") => {
+      if (!date) return "";
+
+      return _format(new Date(date), format, { locale: Locales[formattedLocale] ?? Locales.enUS });
+    },
+    [formattedLocale]
+  );
 
   return { format, subMonths, subWeeks };
 };


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-572

The issue was that the hook useDate is returning a reference everytime any state is updated, this for useMemo is change even if the other data haven't changed this reload the whole page.

Now memoizing the format function in the useDate will cache the function and just change when is needed.