### PR TITLE
[TM-1624] Round 2 of updates to the nothing to report process

### DIFF
--- a/src/components/elements/Table/Table.tsx
+++ b/src/components/elements/Table/Table.tsx
@@ -49,6 +49,7 @@ export interface TableProps<TData>
   initialTableState?: InitialTableState;
   variant?: TableVariant;
   hasPagination?: boolean;
+  resetOnDataChange?: boolean;
   onTableStateChange?: (state: TableState) => void;
   isLoading?: boolean;
   invertSelectPagination?: boolean;
@@ -87,6 +88,7 @@ function Table<TData extends RowData>({
   invertSelectPagination = false,
   hasPagination = false,
   visibleRows = 10,
+  resetOnDataChange = true, // maintains default behavior
   onRowClick,
   contentClassName,
   ...props
@@ -129,7 +131,9 @@ function Table<TData extends RowData>({
       onTableStateChange?.({ sorting, filters });
     },
     getRowId: (row: any) => row.uuid,
-    debugTable: process.env.NODE_ENV === "development"
+    debugTable: process.env.NODE_ENV === "development",
+
+    autoResetAll: resetOnDataChange
   });
 
   const tableState = getState();
@@ -138,7 +142,7 @@ function Table<TData extends RowData>({
     setSorting(initialTableState?.sorting ?? []);
     setPageSize(visibleRows);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, visibleRows]);
+  }, [visibleRows]);
 
   return (
     <div className={classNames("w-full", variant.className, contentClassName)}>

--- a/src/generated/apiComponents.ts
+++ b/src/generated/apiComponents.ts
@@ -19612,21 +19612,27 @@ export type GetV2TasksUUIDReportsError = Fetcher.ErrorWrapper<undefined>;
 
 export type GetV2TasksUUIDReportsResponse = {
   data?: {
-    uuid?: number;
-    type?: string;
-    status?: string;
+    uuid?: string;
     /**
      * @format date-time
      */
     due_at?: string;
-    title?: string;
-    report_title?: string;
-    update_request_status?: string;
     /**
      * @format date-time
      */
     submitted_at?: string;
+    report_title?: string;
+    /**
+     * @format date-time
+     */
+    updated_at?: string;
+    status?: string;
+    update_request_status?: string;
+    nothing_to_report?: boolean;
+    title?: string;
+    type?: string;
     parent_name?: string;
+    completion?: number;
   }[];
 };
 

--- a/src/generated/apiSchemas.ts
+++ b/src/generated/apiSchemas.ts
@@ -22202,21 +22202,27 @@ export type V2TaskRead = {
 };
 
 export type V2TaskActionRead = {
-  uuid?: number;
-  type?: string;
-  status?: string;
+  uuid?: string;
   /**
    * @format date-time
    */
   due_at?: string;
-  title?: string;
-  report_title?: string;
-  update_request_status?: string;
   /**
    * @format date-time
    */
   submitted_at?: string;
+  report_title?: string;
+  /**
+   * @format date-time
+   */
+  updated_at?: string;
+  status?: string;
+  update_request_status?: string;
+  nothing_to_report?: boolean;
+  title?: string;
+  type?: string;
   parent_name?: string;
+  completion?: number;
 };
 
 export type StatusUpdate = {


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1624

In a previous ticket, @Scriptmatico did some work to make the "nothing to report" button correctly disappear after clicking it. However, that implementation turned out to be insufficient because the rest of the row columns weren't updating to reflect the new status. At the time, he did a bunch of investigation into the problem, which goes all the way down to how data is cached in the v2 system and how the Table component chooses to reset its internal state (like current page index) when the data changes. In this PR I've done some work to get that system to behave more appropriately for a case where the table data for a single row may update as a normal consequence of page interaction.

[PHP PR](https://github.com/wri/wri-terramatch-api/pull/649)

NOTE: Build will fail until the PHP PR is deployed.