### PR TITLE
[TM-1715] React hooks rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
       }
     ],
     "no-unused-vars": "off",
-    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/exhaustive-deps": "error",
     "prettier/prettier": [
       "error",
       {},

--- a/src/admin/components/Dialogs/FrameworkSelectionDialog.tsx
+++ b/src/admin/components/Dialogs/FrameworkSelectionDialog.tsx
@@ -84,7 +84,7 @@ export function useFrameworkExport(entity: EntityName, choices: any[]) {
 
       setModalOpen(false);
     },
-    [entity, choices]
+    [entity, role]
   );
 
   return {
@@ -95,7 +95,7 @@ export function useFrameworkExport(entity: EntityName, choices: any[]) {
       } else {
         onExport(choices[0].id);
       }
-    }, [choices]),
+    }, [choices, onExport]),
     frameworkDialogProps: {
       open: modalOpen,
       onCancel: useCallback(() => setModalOpen(false), []),

--- a/src/admin/components/Fields/MapField.tsx
+++ b/src/admin/components/Fields/MapField.tsx
@@ -34,16 +34,17 @@ const MapField = ({ source, emptyText = "Not Provided" }: MapFieldProps) => {
     }
   );
 
-  const setBbboxAndZoom = async () => {
-    if (projectPolygon?.project_polygon?.poly_uuid) {
-      const bbox = await fetchGetV2TerrafundPolygonBboxUuid({
-        pathParams: { uuid: projectPolygon.project_polygon?.poly_uuid }
-      });
-      const bounds: any = bbox.bbox;
-      setPolygonBbox(bounds);
-    }
-  };
   useEffect(() => {
+    const setBbboxAndZoom = async () => {
+      if (projectPolygon?.project_polygon?.poly_uuid) {
+        const bbox = await fetchGetV2TerrafundPolygonBboxUuid({
+          pathParams: { uuid: projectPolygon.project_polygon?.poly_uuid }
+        });
+        const bounds: any = bbox.bbox;
+        setPolygonBbox(bounds);
+      }
+    };
+
     const getDataProjectPolygon = async () => {
       if (!projectPolygon?.project_polygon) {
         setPolygonDataMap({ [FORM_POLYGONS]: [] });

--- a/src/admin/components/ResourceTabs/AuditLogTab/AuditLogTab.tsx
+++ b/src/admin/components/ResourceTabs/AuditLogTab/AuditLogTab.tsx
@@ -57,6 +57,7 @@ const AuditLogTab: FC<IProps> = ({ label, entity, ...rest }) => {
   useEffect(() => {
     refetch();
     loadEntityList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [buttonToggle]);
 
   const isSite = buttonToggle === AuditLogButtonStates.SITE;

--- a/src/admin/components/ResourceTabs/ChangeRequestsTab/ChangeRequestsTab.tsx
+++ b/src/admin/components/ResourceTabs/ChangeRequestsTab/ChangeRequestsTab.tsx
@@ -56,7 +56,10 @@ const ChangeRequestsTab: FC<IProps> = ({ label, entity, singularEntity, ...rest 
   // @ts-ignore
   const form = currentValues?.data?.form;
 
-  const formSteps = useMemo(() => (form == null ? [] : getCustomFormSteps(form, t, undefined, framework)), [form, t]);
+  const formSteps = useMemo(
+    () => (form == null ? [] : getCustomFormSteps(form, t, undefined, framework)),
+    [form, framework, t]
+  );
   const formChanges = useFormChanges(current, changes, formSteps ?? []);
   const numFieldsAffected = useMemo(
     () =>

--- a/src/admin/components/ResourceTabs/MonitoredTab/components/DataCard.tsx
+++ b/src/admin/components/ResourceTabs/MonitoredTab/components/DataCard.tsx
@@ -656,7 +656,7 @@ const DataCard = ({
     if (selectPolygonFromMap?.isOpen) {
       setSelectPolygonFromMap?.({ isOpen: false, uuid: "" });
     }
-  }, [selectPolygonFromMap]);
+  }, [selectPolygonFromMap, setSelectPolygonFromMap]);
 
   const dateRunIndicator = polygonsIndicator?.[polygonsIndicator.length - 1]
     ? format(new Date(polygonsIndicator?.[polygonsIndicator.length - 1]?.created_at!), "dd/MM/yyyy")

--- a/src/admin/components/ResourceTabs/MonitoredTab/hooks/useMonitoredData.ts
+++ b/src/admin/components/ResourceTabs/MonitoredTab/hooks/useMonitoredData.ts
@@ -234,16 +234,16 @@ export const useMonitoredData = (entity?: EntityName, entity_uuid?: string) => {
     ? totalPolygonsApproved
     : totalPolygonsApproved! - Object?.keys(dataToMissingPolygonVerify ?? {})?.length;
 
-  const verifySlug = async (slug: string) =>
-    fetchGetV2IndicatorsEntityUuidSlugVerify({
-      pathParams: {
-        entity: entity!,
-        uuid: entity_uuid!,
-        slug: slug!
-      }
-    });
-
   useEffect(() => {
+    const verifySlug = async (slug: string) =>
+      fetchGetV2IndicatorsEntityUuidSlugVerify({
+        pathParams: {
+          entity: entity!,
+          uuid: entity_uuid!,
+          slug: slug!
+        }
+      });
+
     const fetchSlugs = async () => {
       setIsLoadingVerify(true);
       const slugVerify = await Promise.all(SLUGS_INDICATORS.map(verifySlug));
@@ -269,13 +269,13 @@ export const useMonitoredData = (entity?: EntityName, entity_uuid?: string) => {
         });
       };
       setAnalysisToSlug(slugToAnalysis);
-      await setDropdownAnalysisOptions(updateTitleDropdownOptions);
+      setDropdownAnalysisOptions(updateTitleDropdownOptions);
       setIsLoadingVerify(false);
     };
     if (modalOpened(ModalId.MODAL_RUN_ANALYSIS)) {
       fetchSlugs();
     }
-  }, [entity]);
+  }, [entity, entity_uuid, modalOpened]);
 
   return {
     polygonsIndicator: filteredPolygons,

--- a/src/admin/components/ResourceTabs/PolygonReviewTab/components/PolygonDrawer/PolygonDrawer.tsx
+++ b/src/admin/components/ResourceTabs/PolygonReviewTab/components/PolygonDrawer/PolygonDrawer.tsx
@@ -170,6 +170,7 @@ const PolygonDrawer = ({
       showLoader();
       getValidations({ queryParams: { uuid: polygonSelected } });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkPolygonValidation]);
 
   useEffect(() => {
@@ -195,7 +196,7 @@ const PolygonDrawer = ({
       setSelectedPolygonData({});
       setStatusSelectedPolygon("");
     }
-  }, [polygonSelected, sitePolygonData]);
+  }, [polygonSelected, setStatusSelectedPolygon, sitePolygonData]);
   useEffect(() => {
     if (openEditNewPolygon) {
       setButtonToogle(true);
@@ -230,7 +231,7 @@ const PolygonDrawer = ({
 
     fetchCriteriaValidation();
     setSelectPolygonVersion(selectedPolygonData);
-  }, [buttonToogle, selectedPolygonData]);
+  }, [buttonToogle, polygonSelected, selectedPolygonData]);
 
   const {
     data: polygonVersions,
@@ -252,13 +253,13 @@ const PolygonDrawer = ({
       setIsLoadingDropdown(false);
     };
     onLoading();
-  }, [isOpenPolygonDrawer]);
+  }, [isOpenPolygonDrawer, refetchPolygonVersions]);
 
   useEffect(() => {
     if (selectedPolygonData && isEmpty(selectedPolygonData as SitePolygon) && isEmpty(polygonSelected)) {
       setSelectedPolygonData(selectPolygonVersion);
     }
-  }, [selectPolygonVersion]);
+  }, [polygonSelected, selectPolygonVersion, selectedPolygonData]);
 
   const runFixPolygonOverlaps = () => {
     if (polygonSelected) {

--- a/src/admin/components/ResourceTabs/PolygonReviewTab/components/PolygonDrawer/components/VersionHistory.tsx
+++ b/src/admin/components/ResourceTabs/PolygonReviewTab/components/PolygonDrawer/components/VersionHistory.tsx
@@ -53,7 +53,7 @@ const VersionHistory = ({
   setStatusSelectedPolygon?: any;
   data: GetV2SitePolygonUuidVersionsResponse | [];
   isLoadingVersions: boolean;
-  refetch: () => void;
+  refetch: () => Promise<unknown>;
   isLoadingDropdown: boolean;
   setIsLoadingDropdown: Dispatch<SetStateAction<boolean>>;
   setPolygonFromMap: Dispatch<SetStateAction<{ isOpen: boolean; uuid: string }>>;
@@ -72,6 +72,7 @@ const VersionHistory = ({
 
   useEffect(() => {
     refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectPolygonVersion]);
 
   useEffect(() => {
@@ -79,6 +80,7 @@ const VersionHistory = ({
       uploadFiles();
       setSaveFlags(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files, saveFlags]);
 
   const getFileType = (file: UploadedFile) => {
@@ -305,7 +307,7 @@ const VersionHistory = ({
       };
       reloadVersionList();
     }
-  }, [polygonFromMap]);
+  }, [polygonFromMap, refetch, setIsLoadingDropdown]);
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/admin/components/ResourceTabs/PolygonReviewTab/components/PolygonItem.tsx
+++ b/src/admin/components/ResourceTabs/PolygonReviewTab/components/PolygonItem.tsx
@@ -66,7 +66,7 @@ const PolygonItem = ({
     } else if (criteriaData?.criteria_list && criteriaData.criteria_list.length === 0) {
       setValidationStatus("notChecked");
     }
-  }, [polygonMap]);
+  }, [polygonMap, uuid]);
 
   const handleCheckboxClick = () => {
     onCheckboxChange(uuid, !isChecked);

--- a/src/admin/hooks/useCanUserEdit.ts
+++ b/src/admin/hooks/useCanUserEdit.ts
@@ -5,7 +5,7 @@ import { useGetUserRole } from "./useGetUserRole";
 export const useCanUserEdit = (record: any, resource: string) => {
   const { isFrameworkAdmin, isSuperAdmin, role } = useGetUserRole();
 
-  const canEdit = useMemo(() => {
+  return useMemo(() => {
     if (resource === "user") {
       if (isSuperAdmin) {
         return true;
@@ -17,13 +17,9 @@ export const useCanUserEdit = (record: any, resource: string) => {
         return true;
       }
       if (isFrameworkAdmin) {
-        if (record?.role === role) {
-          return true;
-        }
-        return false;
+        return record?.role === role;
       }
     }
     return !!record;
-  }, [record, resource, isFrameworkAdmin, isSuperAdmin]);
-  return canEdit;
+  }, [resource, record, isSuperAdmin, isFrameworkAdmin, role]);
 };

--- a/src/admin/modules/user/components/UserCreate.tsx
+++ b/src/admin/modules/user/components/UserCreate.tsx
@@ -46,7 +46,7 @@ const UserCreate = () => {
     }
 
     return [...frameworkAdminPrimaryRoleChoices, userPrimaryRoleChoices.find(choice => choice.id === role)];
-  }, [isFrameworkAdmin]);
+  }, [isSuperAdmin, role]);
 
   return (
     <Create title="Create User">

--- a/src/admin/modules/user/components/UserEdit.tsx
+++ b/src/admin/modules/user/components/UserEdit.tsx
@@ -40,7 +40,7 @@ const UserEdit = () => {
     }
 
     return [...frameworkAdminPrimaryRoleChoices, userPrimaryRoleChoices.find(choice => choice.id === role)];
-  }, [isFrameworkAdmin]);
+  }, [isSuperAdmin, role]);
 
   return (
     <Edit title={<UserTitle />} mutationMode="pessimistic" actions={false}>

--- a/src/admin/modules/validationPolygonFile/components/ValidationPolygonFileShow.tsx
+++ b/src/admin/modules/validationPolygonFile/components/ValidationPolygonFileShow.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "@mui/material";
 import { useT } from "@transifex/react";
-import { FC, useEffect, useState } from "react";
+import { FC, useState } from "react";
 
 import Button from "@/components/elements/Button/Button";
 import Text from "@/components/elements/Text/Text";
@@ -14,6 +14,7 @@ import {
   fetchPostV2TerrafundUploadKmlValidate,
   fetchPostV2TerrafundUploadShapefileValidate
 } from "@/generated/apiComponents";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import { FileType, UploadedFile } from "@/types/common";
 import { getErrorMessageFromPayload } from "@/utils/errors";
 
@@ -25,12 +26,12 @@ const ValidatePolygonFileShow: FC = () => {
   const { openNotification } = useNotificationContext();
 
   const t = useT();
-  useEffect(() => {
+  useValueChanged(saveFlags, () => {
     if (file && saveFlags) {
       uploadFile();
       setSaveFlags(false);
     }
-  }, [saveFlags]);
+  });
 
   const getFileType = (file: UploadedFile) => {
     const fileType = file?.file_name.split(".").pop()?.toLowerCase();

--- a/src/components/elements/ImageGallery/ImageGallery.tsx
+++ b/src/components/elements/ImageGallery/ImageGallery.tsx
@@ -13,6 +13,7 @@ import Pagination from "@/components/extensive/Pagination";
 import { VARIANT_PAGINATION_TEXT_16 } from "@/components/extensive/Pagination/PaginationVariant";
 import Loader from "@/components/generic/Loading/Loader";
 import { useModalContext } from "@/context/modal.provider";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import { Option } from "@/types/common";
 
 import FilterSearchBox from "../TableFilters/Inputs/FilterSearchBox";
@@ -99,11 +100,12 @@ const ImageGallery = ({
           )
         : "Filter"
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [privacy, source]);
 
-  useEffect(() => {
+  useValueChanged(sortOrder, () => {
     setSortLabel(sortOrder === "asc" ? t("Oldest to Newest") : t("Newest to Oldest"));
-  }, [sortOrder]);
+  });
 
   const tabs = [
     { key: "0", render: "All Images" },
@@ -321,9 +323,10 @@ const ImageGallery = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageIndex, pageSize, modelName]);
 
-  useEffect(() => {
+  useValueChanged(activeIndex, () => {
     onChangeGeotagged(activeIndex);
-  }, [activeIndex]);
+  });
+
   return (
     <>
       <div {...rest} className={classNames("space-y-8", className)}>

--- a/src/components/elements/Inputs/ConditionalInput/ConditionalInput.tsx
+++ b/src/components/elements/Inputs/ConditionalInput/ConditionalInput.tsx
@@ -7,6 +7,7 @@ import RadioGroup from "@/components/elements/Inputs/RadioGroup/RadioGroup";
 import List from "@/components/extensive/List/List";
 import { FieldMapper } from "@/components/extensive/WizardForm/FieldMapper";
 import { FormField } from "@/components/extensive/WizardForm/types";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import { OptionValueWithBoolean } from "@/types/common";
 
 export interface ConditionalInputProps extends Omit<InputProps, "defaultValue">, UseControllerProps {
@@ -41,7 +42,7 @@ const ConditionalInput = (props: ConditionalInputProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.value, formHook]);
 
-  useEffect(() => {
+  useValueChanged(valueCondition, () => {
     if (valueCondition == true) {
       field.onChange(true);
       return;
@@ -71,7 +72,7 @@ const ConditionalInput = (props: ConditionalInputProps) => {
     if (fieldsCount == fields?.length) {
       field.onChange(false);
     }
-  }, [valueCondition]);
+  });
 
   return (
     <>

--- a/src/components/elements/Inputs/DataTable/DataTable.tsx
+++ b/src/components/elements/Inputs/DataTable/DataTable.tsx
@@ -67,7 +67,7 @@ function DataTable<TData extends RowData & { uuid: string }>(props: DataTablePro
       handleCreate?.(fieldValues);
       closeModal(ModalId.FORM_MODAL);
     },
-    [generateUuids, value, onChange, handleCreate, closeModal]
+    [generateUuids, onChange, value, handleCreate, closeModal, additionalValues]
   );
 
   const onDeleteEntry = useCallback(

--- a/src/components/elements/Inputs/Map/RHFMap.tsx
+++ b/src/components/elements/Inputs/Map/RHFMap.tsx
@@ -72,16 +72,18 @@ const RHFMap = ({
       cacheTime: 0
     }
   );
-  const setBbboxAndZoom = async () => {
-    if (projectPolygon?.project_polygon?.poly_uuid) {
-      const bbox = await fetchGetV2TerrafundPolygonBboxUuid({
-        pathParams: { uuid: projectPolygon.project_polygon?.poly_uuid ?? "" }
-      });
-      const bounds: any = bbox.bbox;
-      setPolygonBbox(bounds);
-    }
-  };
+
   useEffect(() => {
+    const setBbboxAndZoom = async () => {
+      if (projectPolygon?.project_polygon?.poly_uuid) {
+        const bbox = await fetchGetV2TerrafundPolygonBboxUuid({
+          pathParams: { uuid: projectPolygon.project_polygon?.poly_uuid ?? "" }
+        });
+        const bounds: any = bbox.bbox;
+        setPolygonBbox(bounds);
+      }
+    };
+
     const getDataProjectPolygon = async () => {
       if (!projectPolygon?.project_polygon) {
         setPolygonDataMap({ [FORM_POLYGONS]: [] });
@@ -93,8 +95,9 @@ const RHFMap = ({
         setPolygonFromMap({ isOpen: true, uuid: projectPolygon?.project_polygon?.poly_uuid });
       }
     };
+
     getDataProjectPolygon();
-  }, [projectPolygon, isRefetching]);
+  }, [projectPolygon, isRefetching, setSelectPolygonFromMap]);
 
   useEffect(() => {
     if (entity) {

--- a/src/components/elements/Map-mapbox/Map.tsx
+++ b/src/components/elements/Map-mapbox/Map.tsx
@@ -34,6 +34,8 @@ import {
   usePutV2TerrafundPolygonUuid
 } from "@/generated/apiComponents";
 import { DashboardGetProjectsData, SitePolygonsDataResponse } from "@/generated/apiSchemas";
+import { useOnMount } from "@/hooks/useOnMount";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import Log from "@/utils/log";
 
 import { ImageGalleryItemData } from "../ImageGallery/ImageGalleryItem";
@@ -222,7 +224,7 @@ export const MapContainer = ({
   const { map, mapContainer, draw, onCancel, styleLoaded, initMap, setStyleLoaded, setChangeStyle, changeStyle } =
     mapFunctions;
 
-  useEffect(() => {
+  useOnMount(() => {
     initMap(!!isDashboard);
     return () => {
       if (map.current) {
@@ -231,7 +233,7 @@ export const MapContainer = ({
         map.current = null;
       }
     };
-  }, []);
+  });
 
   useEffect(() => {
     if (!map) return;
@@ -240,7 +242,7 @@ export const MapContainer = ({
     }
   }, [map, location]);
 
-  useEffect(() => {
+  useValueChanged(isUserDrawingEnabled, () => {
     if (map?.current && draw?.current) {
       if (isUserDrawingEnabled) {
         startDrawing(draw.current, map.current);
@@ -251,7 +253,7 @@ export const MapContainer = ({
         stopDrawing(draw.current, map.current);
       }
     }
-  }, [isUserDrawingEnabled]);
+  });
 
   useEffect(() => {
     if (map?.current && (isDashboard || !_.isEmpty(polygonsData))) {
@@ -292,25 +294,26 @@ export const MapContainer = ({
         });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sitePolygonData, polygonsData, showPopups, centroids, styleLoaded]);
 
-  useEffect(() => {
+  useValueChanged(currentStyle, () => {
     if (currentStyle) {
       setChangeStyle(false);
     }
-  }, [currentStyle]);
+  });
 
-  useEffect(() => {
+  useValueChanged(changeStyle, () => {
     if (!changeStyle) {
       setStyleLoaded(false);
     }
-  }, [changeStyle]);
+  });
 
-  useEffect(() => {
+  useValueChanged(bbox, () => {
     if (bbox && map.current && map && shouldBboxZoom) {
       zoomToBbox(bbox, map.current, hasControls);
     }
-  }, [bbox]);
+  });
   useEffect(() => {
     if (!map.current || !sourcesAdded) return;
     const setupBorders = () => {
@@ -327,6 +330,7 @@ export const MapContainer = ({
         setupBorders();
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCountry, styleLoaded, sourcesAdded]);
   useEffect(() => {
     if (!map.current || !sourcesAdded) return;
@@ -344,6 +348,7 @@ export const MapContainer = ({
         setupBorders();
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedLandscapes, styleLoaded, sourcesAdded]);
   useEffect(() => {
     if (!map.current || !projectUUID) return;
@@ -354,6 +359,7 @@ export const MapContainer = ({
         setMapStyle(MapStyle.Satellite, map.current, setCurrentStyle, currentStyle);
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectUUID, styleLoaded]);
   useEffect(() => {
     const projectUUID = router.query.uuid as string;
@@ -453,13 +459,14 @@ export const MapContainer = ({
         removeMediaLayer(map.current);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props?.modelFilesData, showMediaPopups, styleLoaded]);
 
-  useEffect(() => {
+  useValueChanged(showMediaPopups, () => {
     if (geojson && map.current && draw.current) {
       addGeojsonToDraw(geojson, "", () => {}, draw.current, map.current);
     }
-  }, [showMediaPopups]);
+  });
 
   function handleAddGeojsonToDraw(polygonuuid: string) {
     if (polygonsData && map.current && draw.current) {
@@ -490,6 +497,7 @@ export const MapContainer = ({
         newPolygonData
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPolygonsInCheckbox, styleLoaded]);
 
   const handleEditPolygon = async () => {
@@ -576,7 +584,7 @@ export const MapContainer = ({
     drawTemporaryPolygon(polygonGeojson?.geojson, () => {}, map.current, selectedPolyVersion);
   };
 
-  useEffect(() => {
+  useValueChanged(selectedPolyVersion, () => {
     if (map?.current?.getSource("temp-polygon-source") || map?.current?.getLayer("temp-polygon-source-line")) {
       map?.current.removeLayer("temp-polygon-source-line");
       map?.current?.removeLayer("temp-polygon-source");
@@ -586,7 +594,7 @@ export const MapContainer = ({
     if (selectedPolyVersion) {
       addGeometryVersion();
     }
-  }, [selectedPolyVersion]);
+  });
 
   return (
     <div ref={mapContainer} className={twMerge("h-[500px] wide:h-[700px]", className)} id="map-container">

--- a/src/components/elements/Map-mapbox/MapControls/CheckIndividualPolygonControl.tsx
+++ b/src/components/elements/Map-mapbox/MapControls/CheckIndividualPolygonControl.tsx
@@ -1,5 +1,5 @@
 import { useT } from "@transifex/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { When } from "react-if";
 
 import { useLoading } from "@/context/loaderAdmin.provider";
@@ -11,6 +11,7 @@ import {
   usePostV2TerrafundValidationPolygon
 } from "@/generated/apiComponents";
 import { ClippedPolygonResponse, SitePolygonsDataResponse } from "@/generated/apiSchemas";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import Log from "@/utils/log";
 
 import Button from "../../Button/Button";
@@ -83,12 +84,12 @@ const CheckIndividualPolygonControl = ({ viewRequestSuport }: { viewRequestSupor
     }
   });
 
-  useEffect(() => {
+  useValueChanged(clickedValidation, () => {
     if (clickedValidation) {
       showLoader();
       getValidations({ queryParams: { uuid: editPolygon.uuid } });
     }
-  }, [clickedValidation]);
+  });
 
   return (
     <div className="flex gap-2">

--- a/src/components/elements/Map-mapbox/MapControls/EditControl.tsx
+++ b/src/components/elements/Map-mapbox/MapControls/EditControl.tsx
@@ -1,8 +1,9 @@
 import { useT } from "@transifex/react";
-import React, { useEffect } from "react";
+import React from "react";
 import { When } from "react-if";
 
 import { useMapAreaContext } from "@/context/mapArea.provider";
+import { useOnMount } from "@/hooks/useOnMount";
 
 import Button from "../../Button/Button";
 import Text from "../../Text/Text";
@@ -11,11 +12,11 @@ const EditControl = ({ onClick, onSave, onCancel }: { onClick?: any; onSave?: an
   const t = useT();
   const [isEditing, setIsEditing] = React.useState(false);
   const { selectedPolyVersion } = useMapAreaContext();
-  useEffect(() => {
+  useOnMount(() => {
     return () => {
       onCancel();
     };
-  }, []);
+  });
   const handleSaveButton = () => {
     onSave();
     setIsEditing(false);

--- a/src/components/elements/Map-mapbox/MapControls/PolygonHandler.tsx
+++ b/src/components/elements/Map-mapbox/MapControls/PolygonHandler.tsx
@@ -39,6 +39,7 @@ export const PolygonHandler = () => {
       uploadFile();
       setSaveFlags(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [file, saveFlags]);
 
   const uploadFile = async () => {

--- a/src/components/elements/Map-mapbox/MapControls/ViewImageCarousel.tsx
+++ b/src/components/elements/Map-mapbox/MapControls/ViewImageCarousel.tsx
@@ -1,9 +1,10 @@
 import { useT } from "@transifex/react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import ModalImageGallery, { TabImagesItem } from "@/components/extensive/Modal/ModalImageGallery";
 import { GetV2MODELUUIDFilesResponse } from "@/generated/apiComponents";
+import { useOnMount } from "@/hooks/useOnMount";
 
 import Button from "../../Button/Button";
 import Text from "../../Text/Text";
@@ -50,7 +51,7 @@ const ViewImageCarousel = ({
         }))
       }
     ];
-  }, [modelFilesData]);
+  }, [modelFilesData, t]);
 
   const [openModal, setOpenModal] = useState(false);
 
@@ -91,12 +92,12 @@ const ViewImageCarousel = ({
     scrollToGalleryElement();
   };
 
-  useEffect(() => {
+  useOnMount(() => {
     if (sessionStorage.getItem("scrollToElement") === "true") {
       scrollToGalleryElement();
       sessionStorage.removeItem("scrollToElement");
     }
-  }, []);
+  });
 
   return (
     <div className="relative">

--- a/src/components/elements/Map-mapbox/components/DashboardPopup.tsx
+++ b/src/components/elements/Map-mapbox/components/DashboardPopup.tsx
@@ -113,6 +113,7 @@ export const DashboardPopup = (event: any) => {
     } else if (itemUuid && layerName === LAYERS_NAMES.POLYGON_GEOMETRY) {
       fetchPolygonData();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isoCountry, layerName, itemUuid]);
   const learnMoreEvent = () => {
     if (isoCountry && layerName === LAYERS_NAMES.WORLD_COUNTRIES) {

--- a/src/components/elements/Map-mapbox/components/OverviewMapArea.tsx
+++ b/src/components/elements/Map-mapbox/components/OverviewMapArea.tsx
@@ -18,6 +18,7 @@ import {
 import { SitePolygonsDataResponse } from "@/generated/apiSchemas";
 import useLoadCriteriaSite from "@/hooks/paginated/useLoadCriteriaSite";
 import { useDate } from "@/hooks/useDate";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import { createQueryParams } from "@/utils/dashboardUtils";
 
 import MapPolygonPanel from "../../MapPolygonPanel/MapPolygonPanel";
@@ -79,7 +80,7 @@ const OverviewMapArea = ({
     loading
   } = useLoadCriteriaSite(entityModel.uuid, type, checkedValues.join(","), sortOrder);
 
-  useEffect(() => {
+  useValueChanged(loading, () => {
     setPolygonCriteriaMap(polygonCriteriaMap);
     setPolygonData(polygonsData);
     if (loading) {
@@ -90,9 +91,10 @@ const OverviewMapArea = ({
     } else {
       callCountryBBox();
     }
-  }, [loading]);
+  });
   useEffect(() => {
     refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkedValues, sortOrder]);
   const callEntityBbox = async () => {
     if (type === "sites") {
@@ -129,7 +131,7 @@ const OverviewMapArea = ({
     if (entityBbox !== null) {
       setShouldRefetchPolygonData(false);
     }
-  }, [entityBbox, polygonsData]);
+  }, [entityBbox, polygonsData, setShouldRefetchPolygonData]);
 
   useEffect(() => {
     const { isOpen, uuid } = editPolygon;
@@ -137,20 +139,20 @@ const OverviewMapArea = ({
     if (isOpen) {
       setSelectedPolygonsInCheckbox([]);
     }
-  }, [editPolygon]);
+  }, [editPolygon, setSelectedPolygonsInCheckbox]);
 
-  useEffect(() => {
+  useValueChanged(shouldRefetchPolygonData, () => {
     if (shouldRefetchPolygonData) {
       reloadSiteData?.();
       refetch();
     }
-  }, [shouldRefetchPolygonData]);
-  useEffect(() => {
+  });
+  useValueChanged(shouldRefetchValidation, () => {
     if (shouldRefetchValidation) {
       refetch();
       setShouldRefetchValidation(false);
     }
-  }, [shouldRefetchValidation]);
+  });
   useEffect(() => {
     if (polygonsData?.length > 0) {
       const dataMap = parsePolygonData(polygonsData);

--- a/src/components/elements/MapPolygonPanel/MapEditPolygonPanel.tsx
+++ b/src/components/elements/MapPolygonPanel/MapEditPolygonPanel.tsx
@@ -1,11 +1,13 @@
 import { useT } from "@transifex/react";
 import classNames from "classnames";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { When } from "react-if";
 
 import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import { useMapAreaContext } from "@/context/mapArea.provider";
 import { SitePolygon, SitePolygonsDataResponse, V2TerrafundCriteriaData } from "@/generated/apiSchemas";
+import { useOnMount } from "@/hooks/useOnMount";
+import { useValueChanged } from "@/hooks/useValueChanged";
 
 import Button from "../Button/Button";
 import Text from "../Text/Text";
@@ -46,9 +48,9 @@ const MapEditPolygonPanel = ({
     setHasOverlaps
   } = useMapAreaContext();
   const { onCancel } = mapFunctions;
-  useEffect(() => {
+  useOnMount(() => {
     setTabEditPolygon("Attributes");
-  }, []);
+  });
   const handleClose = () => {
     setEditPolygon?.({ isOpen: false, uuid: "", primary_uuid: "" });
     setHasOverlaps(false);
@@ -72,13 +74,13 @@ const MapEditPolygonPanel = ({
     return false;
   };
 
-  useEffect(() => {
+  useValueChanged(polygonMap, () => {
     const criteriaDataPolygon = polygonMap[editPolygon?.uuid ?? ""];
     if (criteriaDataPolygon) {
       setHasOverlaps(hasOverlaps(criteriaDataPolygon));
       setCriteriaData(criteriaDataPolygon);
     }
-  }, [polygonMap]);
+  });
 
   return (
     <>

--- a/src/components/elements/MapPolygonPanel/MapMenuPanelItem.tsx
+++ b/src/components/elements/MapPolygonPanel/MapMenuPanelItem.tsx
@@ -73,7 +73,7 @@ const MapMenuPanelItem = ({
     } else {
       setValidationStatus(undefined);
     }
-  }, [polygonMap, setValidationStatus]);
+  }, [poly_id, polygonMap, setValidationStatus]);
 
   const openFormModalHandlerConfirm = () => {
     openModal(

--- a/src/components/elements/MapPolygonPanel/MapPolygonCheckPanel.tsx
+++ b/src/components/elements/MapPolygonPanel/MapPolygonCheckPanel.tsx
@@ -68,7 +68,6 @@ const MapPolygonCheckPanel = ({ emptyText, onLoadMore, selected, mapFunctions }:
   const { siteData } = useMapAreaContext();
   const context = useSitePolygonData();
   const [polygonsValidationData, setPolygonsValidationData] = useState<any[]>([]);
-  const sitePolygonData = context?.sitePolygonData ?? [];
 
   const { data: currentValidationSite } = useGetV2TerrafundValidationSite<CheckedPolygon[]>(
     {
@@ -83,10 +82,11 @@ const MapPolygonCheckPanel = ({ emptyText, onLoadMore, selected, mapFunctions }:
 
   useEffect(() => {
     if (currentValidationSite) {
+      const sitePolygonData = context?.sitePolygonData ?? [];
       const data = parseData(sitePolygonData, currentValidationSite, validationLabels);
       setPolygonsValidationData(data);
     }
-  }, [currentValidationSite, sitePolygonData]);
+  }, [context?.sitePolygonData, currentValidationSite]);
 
   return (
     <>

--- a/src/components/elements/MapPolygonPanel/VersionInformation.tsx
+++ b/src/components/elements/MapPolygonPanel/VersionInformation.tsx
@@ -22,6 +22,7 @@ import {
   usePutV2SitePolygonUuidMakeActive
 } from "@/generated/apiComponents";
 import { SitePolygon, SitePolygonsDataResponse } from "@/generated/apiSchemas";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import { FileType, UploadedFile } from "@/types/common";
 import { getErrorMessageFromPayload } from "@/utils/errors";
 
@@ -91,6 +92,7 @@ const VersionInformation = ({
       uploadFiles();
       setSaveFlags(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files, saveFlags]);
 
   const getFileType = (file: UploadedFile) => {
@@ -267,9 +269,9 @@ const VersionInformation = ({
     });
   };
 
-  useEffect(() => {
+  useValueChanged(selectedPolyVersion, () => {
     recallEntityData?.();
-  }, [selectedPolyVersion]);
+  });
 
   const makeActivePolygon = async (polygon: any) => {
     const versionActive = (polygonVersionData as SitePolygonsDataResponse)?.find(

--- a/src/components/elements/MapSidePanel/MapSidePanel.tsx
+++ b/src/components/elements/MapSidePanel/MapSidePanel.tsx
@@ -116,6 +116,7 @@ const MapSidePanel = ({
       }
       setClickedButton("");
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clickedButton, selected]);
 
   useEffect(() => {
@@ -222,6 +223,7 @@ const MapSidePanel = ({
             itemAs={Fragment}
             render={item => (
               <MapMenuPanelItem
+                key={item.uuid}
                 uuid={item.uuid}
                 title={item.title}
                 subtitle={item.subtitle}

--- a/src/components/elements/Tabs/Secondary/SecondaryTabs.tsx
+++ b/src/components/elements/Tabs/Secondary/SecondaryTabs.tsx
@@ -1,12 +1,13 @@
 import { Tab as HTab } from "@headlessui/react";
 import classNames from "classnames";
 import { useRouter } from "next/router";
-import { DetailedHTMLProps, Fragment, HTMLAttributes, ReactElement, useEffect, useRef } from "react";
+import { DetailedHTMLProps, Fragment, HTMLAttributes, ReactElement, useRef } from "react";
 
 import Text from "@/components/elements/Text/Text";
 import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import List from "@/components/extensive/List/List";
 import { Framework, useFrameworkContext } from "@/context/framework.provider";
+import { useValueChanged } from "@/hooks/useValueChanged";
 
 import Button from "../../Button/Button";
 import { SecundaryTabsVariants, VARIANT_TABS_PRIMARY } from "./SecuandaryTabsVariants";
@@ -71,11 +72,11 @@ const SecondaryTabs = ({
     setSelectedIndex && setSelectedIndex(index);
   };
 
-  useEffect(() => {
+  useValueChanged(selectedIndex, () => {
     if (selectedIndex !== undefined) {
       onTabChange(selectedIndex);
     }
-  }, [selectedIndex]);
+  });
 
   const handleScrollNext = () => {
     if (ContentListRef.current) {

--- a/src/components/elements/Tooltip/Tooltip.tsx
+++ b/src/components/elements/Tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useEffect, useRef, useState } from "react";
 import { When } from "react-if";
 import { twMerge as tw } from "tailwind-merge";
 
+import { useOnMount } from "@/hooks/useOnMount";
 import { TextVariants } from "@/types/common";
 
 import Text from "../Text/Text";
@@ -84,7 +85,7 @@ const ToolTip = ({
     }
   };
 
-  useEffect(() => {
+  useOnMount(() => {
     const handleResize = () => {
       updateTooltipPosition();
     };
@@ -93,7 +94,7 @@ const ToolTip = ({
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, []);
+  });
 
   const updateTooltipPosition = () => {
     const position = contentRef.current?.getBoundingClientRect();

--- a/src/components/extensive/EntityMapAndGalleryCard/EntityMapAndGalleryCard.tsx
+++ b/src/components/extensive/EntityMapAndGalleryCard/EntityMapAndGalleryCard.tsx
@@ -1,6 +1,6 @@
 import { useT } from "@transifex/react";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Else, If, Then } from "react-if";
 
 import Button from "@/components/elements/Button/Button";
@@ -25,6 +25,7 @@ import {
 } from "@/generated/apiComponents";
 import { getCurrentPathEntity } from "@/helpers/entity";
 import { useGetImagesGeoJSON } from "@/hooks/useImageGeoJSON";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import { EntityName, FileType } from "@/types/common";
 import Log from "@/utils/log";
 
@@ -134,12 +135,12 @@ const EntityMapAndGalleryCard = ({
     return mapping?.[modelName] || [];
   }, [modelName, t]);
 
-  useEffect(() => {
+  useValueChanged(shouldRefetchMediaData, () => {
     if (shouldRefetchMediaData) {
       refetch();
       setShouldRefetchMediaData(false);
     }
-  }, [shouldRefetchMediaData]);
+  });
 
   const openFormModalHandlerUploadImages = () => {
     openModal(

--- a/src/components/extensive/Modal/ModalFixOverlaps.tsx
+++ b/src/components/extensive/Modal/ModalFixOverlaps.tsx
@@ -116,7 +116,7 @@ const ModalFixOverlaps: FC<ModalFixOverlapsProps> = ({
         };
       })
     );
-  }, [polygonList, polygonsCriteriaData, t, memoizedCheckValidCriteria]);
+  }, [polygonList, polygonsCriteriaData, t, memoizedCheckValidCriteria, selectedUUIDs]);
 
   return (
     <ModalBaseSubmit {...rest}>

--- a/src/components/extensive/Modal/ModalImageDetails.tsx
+++ b/src/components/extensive/Modal/ModalImageDetails.tsx
@@ -1,6 +1,6 @@
 import { useT } from "@transifex/react";
 import Image from "next/image";
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useState } from "react";
 
 import Button from "@/components/elements/Button/Button";
 import Input from "@/components/elements/Inputs/Input/Input";
@@ -14,6 +14,7 @@ import Modal from "@/components/extensive/Modal/Modal";
 import { useModalContext } from "@/context/modal.provider";
 import { useNotificationContext } from "@/context/notification.provider";
 import { usePatchV2MediaProjectProjectMediaUuid, usePatchV2MediaUuid } from "@/generated/apiComponents";
+import { useOnMount } from "@/hooks/useOnMount";
 import Log from "@/utils/log";
 
 import Icon, { IconNames } from "../Icon/Icon";
@@ -66,9 +67,9 @@ const ModalImageDetails: FC<ModalImageDetailProps> = ({
   const { mutate: updateMedia, isLoading: isUpdating } = usePatchV2MediaUuid();
   const { mutateAsync: updateIsCoverAsync, isLoading: isUpdatingCover } = usePatchV2MediaProjectProjectMediaUuid();
 
-  useEffect(() => {
+  useOnMount(() => {
     setInitialFormData({ ...formData });
-  }, []);
+  });
 
   const handleInputChange = (name: string, value: string | boolean) => {
     setFormData(prev => ({ ...prev, [name]: value }));

--- a/src/components/extensive/WizardForm/FormSummaryRow.tsx
+++ b/src/components/extensive/WizardForm/FormSummaryRow.tsx
@@ -60,6 +60,7 @@ export const useGetFormEntries = (props: GetFormEntriesProps) => {
   const mapFunctions = useMap();
   return useMemo<any[]>(
     () => getFormEntries(props, t, entityPolygonData, bbox, mapFunctions),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [props, t, entityPolygonData, bbox]
   );
 };

--- a/src/connections/DelayedJob.ts
+++ b/src/connections/DelayedJob.ts
@@ -83,8 +83,8 @@ export const useDelayedJobs = () => {
   }, [hasJobs, startPolling, stopPolling, totalContent]);
 
   useValueChanged(isLoggedIn, () => {
-    // make sure we call the listDelayedJobs request when we first mount if we're logged in, or
-    // when we log in at least once.
+    // make sure we call the listDelayedJobs request at least once when we first mount if we're
+    // logged in, or when we log in with a fresh user.
     if (isLoggedIn) listDelayedJobs();
   });
 

--- a/src/context/mapArea.provider.tsx
+++ b/src/context/mapArea.provider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext, useState } from "react";
+import React, { createContext, ReactNode, useCallback, useContext, useState } from "react";
 
 import { fetchGetV2DashboardViewProjectUuid } from "@/generated/apiComponents";
 import { SitePolygon } from "@/generated/apiSchemas";
@@ -138,7 +138,7 @@ export const MapAreaProvider: React.FC<{ children: ReactNode }> = ({ children })
     setOpenEditNewPolygon(isOpen);
   };
 
-  const checkIsMonitoringPartner = async (projectUuid: string) => {
+  const checkIsMonitoringPartner = useCallback(async (projectUuid: string) => {
     try {
       const isMonitoringPartner: any = await fetchGetV2DashboardViewProjectUuid({
         pathParams: { uuid: projectUuid }
@@ -148,7 +148,7 @@ export const MapAreaProvider: React.FC<{ children: ReactNode }> = ({ children })
       Log.error("Failed to check if monitoring partner:", error);
       setIsMonitoring(false);
     }
-  };
+  }, []);
 
   const contextValue: MapAreaType = {
     isMonitoring,

--- a/src/context/modal.provider.tsx
+++ b/src/context/modal.provider.tsx
@@ -62,6 +62,9 @@ const ModalProvider = ({ children }: ModalProviderProps) => {
       setModalLoading,
       modalOpened
     }),
+    // Only regenerate the context value if the set of current modals changes. This is more
+    // efficient than wrapping every callback above in useCallback()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [modals]
   );
 

--- a/src/context/notification.provider.tsx
+++ b/src/context/notification.provider.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from "react";
+import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import Notification from "@/components/elements/Notification/Notification";
 
@@ -38,13 +38,16 @@ const NotificationProvider = ({ children }: NotificationProviderProps) => {
     open: false
   });
 
-  const openNotification = (type: Exclude<NotificationType, null>, title: string, message?: string | any) => {
-    setNotificationProps({ type, title, message: message ?? undefined, open: true });
-  };
+  const openNotification = useCallback(
+    (type: Exclude<NotificationType, null>, title: string, message?: string | any) => {
+      setNotificationProps({ type, title, message: message ?? undefined, open: true });
+    },
+    []
+  );
 
-  const closeNotification = () => {
+  const closeNotification = useCallback(() => {
     setNotificationProps(prev => ({ ...prev, open: false }));
-  };
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -52,7 +55,7 @@ const NotificationProvider = ({ children }: NotificationProviderProps) => {
       closeNotification,
       notificationProps
     }),
-    [notificationProps]
+    [closeNotification, notificationProps, openNotification]
   );
 
   return (

--- a/src/generated/v3/entityService/entityServiceComponents.ts
+++ b/src/generated/v3/entityService/entityServiceComponents.ts
@@ -64,10 +64,6 @@ export type EstablishmentTreesFindError = Fetcher.ErrorWrapper<
          * @example Bad Request
          */
         message: string;
-        /**
-         * @example Bad Request
-         */
-        error?: string;
       };
     }
   | {
@@ -81,10 +77,6 @@ export type EstablishmentTreesFindError = Fetcher.ErrorWrapper<
          * @example Unauthorized
          */
         message: string;
-        /**
-         * @example Unauthorized
-         */
-        error?: string;
       };
     }
 >;

--- a/src/generated/v3/jobService/jobServiceComponents.ts
+++ b/src/generated/v3/jobService/jobServiceComponents.ts
@@ -18,10 +18,6 @@ export type ListDelayedJobsError = Fetcher.ErrorWrapper<{
      * @example Unauthorized
      */
     message: string;
-    /**
-     * @example Unauthorized
-     */
-    error?: string;
   };
 }>;
 
@@ -65,10 +61,6 @@ export type DelayedJobsFindError = Fetcher.ErrorWrapper<
          * @example Unauthorized
          */
         message: string;
-        /**
-         * @example Unauthorized
-         */
-        error?: string;
       };
     }
   | {
@@ -82,10 +74,6 @@ export type DelayedJobsFindError = Fetcher.ErrorWrapper<
          * @example Not Found
          */
         message: string;
-        /**
-         * @example Not Found
-         */
-        error?: string;
       };
     }
 >;
@@ -131,10 +119,6 @@ export type BulkUpdateJobsError = Fetcher.ErrorWrapper<
          * @example Bad Request
          */
         message: string;
-        /**
-         * @example Bad Request
-         */
-        error?: string;
       };
     }
   | {
@@ -148,10 +132,6 @@ export type BulkUpdateJobsError = Fetcher.ErrorWrapper<
          * @example Unauthorized
          */
         message: string;
-        /**
-         * @example Unauthorized
-         */
-        error?: string;
       };
     }
   | {
@@ -165,10 +145,6 @@ export type BulkUpdateJobsError = Fetcher.ErrorWrapper<
          * @example Not Found
          */
         message: string;
-        /**
-         * @example Not Found
-         */
-        error?: string;
       };
     }
 >;

--- a/src/generated/v3/userService/userServiceComponents.ts
+++ b/src/generated/v3/userService/userServiceComponents.ts
@@ -18,10 +18,6 @@ export type AuthLoginError = Fetcher.ErrorWrapper<{
      * @example Unauthorized
      */
     message: string;
-    /**
-     * @example Unauthorized
-     */
-    error?: string;
   };
 }>;
 
@@ -32,7 +28,7 @@ export type AuthLoginResponse = {
      */
     type?: string;
     /**
-     * @pattern ^\d{5}$
+     * @format uuid
      */
     id?: string;
     attributes?: Schemas.LoginDto;
@@ -56,7 +52,7 @@ export const authLogin = (variables: AuthLoginVariables, signal?: AbortSignal) =
 
 export type UsersFindPathParams = {
   /**
-   * A valid user uuid or "me"
+   * A valid user UUID or "me"
    *
    * @example me
    */
@@ -75,10 +71,6 @@ export type UsersFindError = Fetcher.ErrorWrapper<
          * @example Unauthorized
          */
         message: string;
-        /**
-         * @example Unauthorized
-         */
-        error?: string;
       };
     }
   | {
@@ -92,10 +84,6 @@ export type UsersFindError = Fetcher.ErrorWrapper<
          * @example Not Found
          */
         message: string;
-        /**
-         * @example Not Found
-         */
-        error?: string;
       };
     }
 >;
@@ -145,7 +133,7 @@ export type UsersFindVariables = {
 };
 
 /**
- * Fetch a user by ID, or with the 'me' identifier
+ * Fetch a user by UUID, or with the 'me' identifier
  */
 export const usersFind = (variables: UsersFindVariables, signal?: AbortSignal) =>
   userServiceFetch<UsersFindResponse, UsersFindError, undefined, {}, {}, UsersFindPathParams>({
@@ -174,10 +162,6 @@ export type UserUpdateError = Fetcher.ErrorWrapper<
          * @example Bad Request
          */
         message: string;
-        /**
-         * @example Bad Request
-         */
-        error?: string;
       };
     }
   | {
@@ -191,10 +175,6 @@ export type UserUpdateError = Fetcher.ErrorWrapper<
          * @example Unauthorized
          */
         message: string;
-        /**
-         * @example Unauthorized
-         */
-        error?: string;
       };
     }
   | {
@@ -208,10 +188,6 @@ export type UserUpdateError = Fetcher.ErrorWrapper<
          * @example Not Found
          */
         message: string;
-        /**
-         * @example Not Found
-         */
-        error?: string;
       };
     }
 >;
@@ -262,7 +238,7 @@ export type UserUpdateVariables = {
 };
 
 /**
- * Update a user by ID
+ * Update a user by UUID
  */
 export const userUpdate = (variables: UserUpdateVariables, signal?: AbortSignal) =>
   userServiceFetch<UserUpdateResponse, UserUpdateError, Schemas.UserUpdateBodyDto, {}, {}, UserUpdatePathParams>({
@@ -271,3 +247,96 @@ export const userUpdate = (variables: UserUpdateVariables, signal?: AbortSignal)
     ...variables,
     signal
   });
+
+export type RequestPasswordResetError = Fetcher.ErrorWrapper<{
+  status: 400;
+  payload: {
+    /**
+     * @example 400
+     */
+    statusCode: number;
+    /**
+     * @example Bad Request
+     */
+    message: string;
+  };
+}>;
+
+export type RequestPasswordResetResponse = {
+  data?: {
+    /**
+     * @example passwordResets
+     */
+    type?: string;
+    /**
+     * @format uuid
+     */
+    id?: string;
+    attributes?: Schemas.ResetPasswordResponseDto;
+  };
+};
+
+export type RequestPasswordResetVariables = {
+  body: Schemas.ResetPasswordRequest;
+};
+
+/**
+ * Send password reset email with a token
+ */
+export const requestPasswordReset = (variables: RequestPasswordResetVariables, signal?: AbortSignal) =>
+  userServiceFetch<RequestPasswordResetResponse, RequestPasswordResetError, Schemas.ResetPasswordRequest, {}, {}, {}>({
+    url: "/auth/v3/passwordResets",
+    method: "post",
+    ...variables,
+    signal
+  });
+
+export type ResetPasswordPathParams = {
+  token: string;
+};
+
+export type ResetPasswordError = Fetcher.ErrorWrapper<{
+  status: 400;
+  payload: {
+    /**
+     * @example 400
+     */
+    statusCode: number;
+    /**
+     * @example Bad Request
+     */
+    message: string;
+  };
+}>;
+
+export type ResetPasswordResponse = {
+  data?: {
+    /**
+     * @example passwordResets
+     */
+    type?: string;
+    /**
+     * @format uuid
+     */
+    id?: string;
+    attributes?: Schemas.ResetPasswordResponseDto;
+  };
+};
+
+export type ResetPasswordVariables = {
+  body?: Schemas.ResetPasswordDto;
+  pathParams: ResetPasswordPathParams;
+};
+
+/**
+ * Reset password using the provided token
+ */
+export const resetPassword = (variables: ResetPasswordVariables, signal?: AbortSignal) =>
+  userServiceFetch<
+    ResetPasswordResponse,
+    ResetPasswordError,
+    Schemas.ResetPasswordDto,
+    {},
+    {},
+    ResetPasswordPathParams
+  >({ url: "/auth/v3/passwordResets/{token}", method: "put", ...variables, signal });

--- a/src/generated/v3/userService/userServicePredicates.ts
+++ b/src/generated/v3/userService/userServicePredicates.ts
@@ -4,7 +4,9 @@ import {
   UsersFindPathParams,
   UsersFindVariables,
   UserUpdatePathParams,
-  UserUpdateVariables
+  UserUpdateVariables,
+  ResetPasswordPathParams,
+  ResetPasswordVariables
 } from "./userServiceComponents";
 
 export const authLoginIsFetching = (store: ApiDataStore) =>
@@ -24,3 +26,25 @@ export const userUpdateIsFetching = (variables: Omit<UserUpdateVariables, "body"
 
 export const userUpdateFetchFailed = (variables: Omit<UserUpdateVariables, "body">) => (store: ApiDataStore) =>
   fetchFailed<{}, UserUpdatePathParams>({ store, url: "/users/v3/users/{uuid}", method: "patch", ...variables });
+
+export const requestPasswordResetIsFetching = (store: ApiDataStore) =>
+  isFetching<{}, {}>({ store, url: "/auth/v3/passwordResets", method: "post" });
+
+export const requestPasswordResetFetchFailed = (store: ApiDataStore) =>
+  fetchFailed<{}, {}>({ store, url: "/auth/v3/passwordResets", method: "post" });
+
+export const resetPasswordIsFetching = (variables: Omit<ResetPasswordVariables, "body">) => (store: ApiDataStore) =>
+  isFetching<{}, ResetPasswordPathParams>({
+    store,
+    url: "/auth/v3/passwordResets/{token}",
+    method: "put",
+    ...variables
+  });
+
+export const resetPasswordFetchFailed = (variables: Omit<ResetPasswordVariables, "body">) => (store: ApiDataStore) =>
+  fetchFailed<{}, ResetPasswordPathParams>({
+    store,
+    url: "/auth/v3/passwordResets/{token}",
+    method: "put",
+    ...variables
+  });

--- a/src/generated/v3/userService/userServiceSchemas.ts
+++ b/src/generated/v3/userService/userServiceSchemas.ts
@@ -73,3 +73,19 @@ export type UserUpdate = {
 export type UserUpdateBodyDto = {
   data: UserUpdate;
 };
+
+export type ResetPasswordResponseDto = {
+  /**
+   * User email
+   *
+   * @example user@example.com
+   */
+  emailAddress: string;
+};
+
+export type ResetPasswordRequest = {
+  emailAddress: string;
+  callbackUrl: string;
+};
+
+export type ResetPasswordDto = {};

--- a/src/hooks/AuditStatus/useAuditLogActions.ts
+++ b/src/hooks/AuditStatus/useAuditLogActions.ts
@@ -138,7 +138,7 @@ const useAuditLogActions = ({
       fetchCriteriaValidation();
       fetchCheckPolygons();
     }
-  }, [entityType, record, selected]);
+  }, [entityType, isPolygon, isSite, isSiteProject, record, selected, verifyEntity]);
 
   const isValidCriteriaData = (criteriaData: any) => {
     if (!criteriaData?.criteria_list?.length) {
@@ -190,6 +190,7 @@ const useAuditLogActions = ({
 
   useEffect(() => {
     refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [buttonToggle, record, entityListItem, selected]);
 
   const getValuesStatusEntity = (() => {

--- a/src/hooks/paginated/useLoadCriteriaSite.ts
+++ b/src/hooks/paginated/useLoadCriteriaSite.ts
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import {
   fetchGetV2EntityPolygons,
   fetchGetV2EntityPolygonsCount,
   fetchPostV2TerrafundValidationCriteriaData
 } from "@/generated/apiComponents";
+import { useOnMount } from "@/hooks/useOnMount";
 
 interface LoadCriteriaSiteHook {
   data: any[];
@@ -100,9 +101,7 @@ const useLoadCriteriaSite = (
     });
   };
 
-  useEffect(() => {
-    loadInBatches();
-  }, []);
+  useOnMount(loadInBatches);
 
   return {
     data,

--- a/src/hooks/useDemographicData.tsx
+++ b/src/hooks/useDemographicData.tsx
@@ -135,6 +135,6 @@ export default function useDemographicData(
       const title = t(`${titlePrefix} - {total}`, { total: total ?? "...loading" });
       return { grids, title };
     },
-    [data, collections, framework, t, titlePrefix]
+    [data, collections, framework, t, titlePrefix, variant, demographicalType]
   );
 }

--- a/src/hooks/useHideOnScroll.ts
+++ b/src/hooks/useHideOnScroll.ts
@@ -17,6 +17,7 @@ const useHideOnScroll = (ref: RefObject<HTMLElement>, container?: HTMLElement | 
       container?.removeEventListener("scroll", hideElement);
       window.removeEventListener("scroll", hideElement);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [container]);
 };
 

--- a/src/hooks/useMessageValidations.ts
+++ b/src/hooks/useMessageValidations.ts
@@ -24,17 +24,19 @@ interface ExtraInfoItem {
   error?: string;
 }
 
+const FIELDS_TO_VALIDATE: Record<string, string> = {
+  poly_name: "Polygon Name",
+  plantstart: "Plant Start Date",
+  plantend: "Plant End Date",
+  practice: "Restoration Practice",
+  target_sys: "Target Land Use System",
+  distr: "Tree Distribution",
+  num_trees: "Number of Trees"
+};
+
 export const useMessageValidators = () => {
   const t = useT();
-  const fieldsToValidate: any = {
-    poly_name: "Polygon Name",
-    plantstart: "Plant Start Date",
-    plantend: "Plant End Date",
-    practice: "Restoration Practice",
-    target_sys: "Target Land Use System",
-    distr: "Tree Distribution",
-    num_trees: "Number of Trees"
-  };
+
   const getIntersectionMessages = useMemo(
     () =>
       (extraInfo: any): string[] => {
@@ -91,28 +93,28 @@ export const useMessageValidators = () => {
         return infoArray
           .map(info => {
             if (!info.exists) {
-              return t("{field} is missing", { field: fieldsToValidate[info.field] });
+              return t("{field} is missing", { field: FIELDS_TO_VALIDATE[info.field] });
             }
             switch (info.field) {
               case "target_sys":
                 return t(
                   "{field}: {error} is not a valid {field} because it is not one of ['agroforest', 'natural-forest', 'mangrove', 'peatland', 'riparian-area-or-wetland', 'silvopasture', 'woodlot-or-plantation', 'urban-forest']",
-                  { field: fieldsToValidate[info.field], error: info.error }
+                  { field: FIELDS_TO_VALIDATE[info.field], error: info.error }
                 );
               case "distr":
                 return t(
                   "{field}: {error} is not a valid {field} because it is not one of ['single-line', 'partial', 'full']",
-                  { field: fieldsToValidate[info.field], error: info.error }
+                  { field: FIELDS_TO_VALIDATE[info.field], error: info.error }
                 );
               case "num_trees":
                 return t("{field} {error} is not a valid number", {
-                  field: fieldsToValidate[info.field],
+                  field: FIELDS_TO_VALIDATE[info.field],
                   error: info.error
                 });
               case "practice":
                 return t(
                   "{field}: {error} is not a valid {field} because it is not one of ['tree-planting', 'direct-seeding', 'assisted-natural-regeneration']",
-                  { field: fieldsToValidate[info.field], error: info.error }
+                  { field: FIELDS_TO_VALIDATE[info.field], error: info.error }
                 );
               default:
                 return null;

--- a/src/hooks/useProcessRecordData.ts
+++ b/src/hooks/useProcessRecordData.ts
@@ -26,5 +26,5 @@ export function useProcessRecordData(modelUUID: string, modelName: string, input
     }
 
     return true;
-  }, [record, inputType, modelUUID, modelName]);
+  }, [record, inputType]);
 }

--- a/src/hooks/useReportingWindow.ts
+++ b/src/hooks/useReportingWindow.ts
@@ -40,5 +40,6 @@ export const useReportingWindow = (dueDate: string) => {
     }
 
     return `${start} - ${end} ${year}`;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dueDate]);
 };

--- a/src/hooks/useValueChanged.ts
+++ b/src/hooks/useValueChanged.ts
@@ -1,10 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 /**
  * A hook useful for executing a side effect after component render (in an effect) if the given
- * value changes. Uses strict equals. The primary use of this hook is to prevent a side effect from
- * being executed multiple times if the component re-renders after the value has transitioned to its
- * action state.
+ * value changes. Uses strict equals. The primary use of this hook are:
+ *  * to prevent a side effect from being executed multiple times if the component re-renders after
+ *    the value has transitioned to its action state.
+ *  * to take some action every time a given value changes
  *
  * Callback is guaranteed to execute on the first render of the component. This is intentional. A
  * consumer of this hook is expected to check the current state of the value and take action based
@@ -12,18 +13,20 @@ import { useEffect, useRef } from "react";
  * want the resulting side effect to take place immediately, rather than only when the value has
  * changed.
  *
- * Example:
+ * Examples:
  *
  * useValueChanged(isLoggedIn, () => {
  *   if (isLoggedIn) router.push("/home");
  * }
+ *
+ * useValueChanged(buttonToggle, () => {
+ *   refetch();
+ *   loadEntityList();
+ * });
  */
 export function useValueChanged<T>(value: T, callback: () => void) {
-  const ref = useRef<T>();
   useEffect(() => {
-    if (ref.current !== value) {
-      ref.current = value;
-      callback();
-    }
-  });
+    callback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 }

--- a/src/pages/auth/signup/components/SignupForm.tsx
+++ b/src/pages/auth/signup/components/SignupForm.tsx
@@ -1,6 +1,5 @@
 import { useT } from "@transifex/react";
 import Link from "next/link";
-import { useEffect } from "react";
 import { UseFormReturn } from "react-hook-form";
 
 import Checkbox from "@/components/elements/Inputs/Checkbox/Checkbox";
@@ -9,6 +8,7 @@ import Text from "@/components/elements/Text/Text";
 import Form from "@/components/extensive/Form/Form";
 import PasswordStrength from "@/components/extensive/PasswordStrength/PasswordStrength";
 import { privacyPolicyLink, termsAndConditionsLink } from "@/constants/links";
+import { useValueChanged } from "@/hooks/useValueChanged";
 
 import LoginLayout from "../../layout";
 import { SignUpFormData } from "../index.page";
@@ -24,9 +24,9 @@ const SignUpForm = ({ form, loading, handleSave, role }: SignUpFormProps) => {
   const t = useT();
   const errors = form.formState.errors;
 
-  useEffect(() => {
+  useValueChanged(role, () => {
     form.setValue("role", "project-developer");
-  }, [role]);
+  });
 
   return (
     <LoginLayout>

--- a/src/pages/dashboard/components/ContentOverview.tsx
+++ b/src/pages/dashboard/components/ContentOverview.tsx
@@ -3,6 +3,7 @@ import { useT } from "@transifex/react";
 import React, { useEffect, useState } from "react";
 
 import Button from "@/components/elements/Button/Button";
+import { BBox } from "@/components/elements/Map-mapbox/GeoJSON";
 import { useMap } from "@/components/elements/Map-mapbox/hooks/useMap";
 import { MapContainer } from "@/components/elements/Map-mapbox/Map";
 import Table from "@/components/elements/Table/Table";
@@ -11,8 +12,7 @@ import {
   VARIANT_TABLE_DASHBOARD_COUNTRIES_MODAL
 } from "@/components/elements/Table/TableVariants";
 import Text from "@/components/elements/Text/Text";
-import Icon from "@/components/extensive/Icon/Icon";
-import { IconNames } from "@/components/extensive/Icon/Icon";
+import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import List from "@/components/extensive/List/List";
 import { ModalId } from "@/components/extensive/Modal/ModalConst";
 import ModalExpand from "@/components/extensive/Modal/ModalExpand";
@@ -34,7 +34,6 @@ import {
   TOTAL_NUMBER_OF_SITES_TOOLTIP
 } from "../constants/tooltips";
 import { CARD_IMPACT_STORY_MOCKED_DATA } from "../mockedData/impactStory";
-import { BBox } from "./../../../components/elements/Map-mapbox/GeoJSON";
 import SecDashboard from "./SecDashboard";
 import TooltipGridMap from "./TooltipGridMap";
 
@@ -108,7 +107,7 @@ const ContentOverview = (props: ContentOverviewProps<RowData>) => {
 
   useEffect(() => {
     setModalLoading("modalExpand", modalMapLoaded);
-  }, [modalMapLoaded]);
+  }, [modalMapLoaded, setModalLoading]);
   const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max));
   const handleCloseModal = () => {
     const { map } = modalMapFunctions;

--- a/src/pages/dashboard/components/HeaderDashboard.tsx
+++ b/src/pages/dashboard/components/HeaderDashboard.tsx
@@ -17,6 +17,7 @@ import { CountriesProps } from "@/components/generic/Layout/DashboardLayout";
 import { useDashboardContext } from "@/context/dashboard.provider";
 import { useLoading } from "@/context/loaderAdmin.provider";
 import { useGetV2DashboardFrameworks } from "@/generated/apiComponents";
+import { useOnMount } from "@/hooks/useOnMount";
 import { OptionValue } from "@/types/common";
 
 import { PROJECT_INSIGHTS_SECTION_TOOLTIP } from "../constants/tooltips";
@@ -103,7 +104,7 @@ const HeaderDashboard = (props: HeaderDashboardProps) => {
     if (frameworks) {
       setFrameworks(frameworks);
     }
-  }, [frameworks]);
+  }, [frameworks, setFrameworks]);
 
   const resetValues = () => {
     setFilters({
@@ -144,9 +145,9 @@ const HeaderDashboard = (props: HeaderDashboardProps) => {
       undefined,
       { shallow: true }
     );
-  }, [filters]);
+  }, [filters, router]);
 
-  useEffect(() => {
+  useOnMount(() => {
     setDashboardCountries(dashboardCountries);
     const { programmes, landscapes, country, organizations, cohort, uuid } = router.query;
     const newFilters = {
@@ -159,7 +160,7 @@ const HeaderDashboard = (props: HeaderDashboardProps) => {
     };
 
     setFilters(newFilters);
-  }, []);
+  });
 
   const handleChange = (selectName: string, value: OptionValue[]) => {
     setFilters(prevValues => ({

--- a/src/pages/dashboard/components/SecDashboard.tsx
+++ b/src/pages/dashboard/components/SecDashboard.tsx
@@ -21,6 +21,7 @@ import {
   DUMMY_DATA_TARGET_LAND_USE_TYPES_REPRESENTED,
   TEXT_TYPES
 } from "@/constants/dashboardConsts";
+import { useOnMount } from "@/hooks/useOnMount";
 import { TextVariants } from "@/types/common";
 import { getRestorationGoalDataForChart, getRestorationGoalResumeData, isEmptyChartData } from "@/utils/dashboardUtils";
 
@@ -31,8 +32,7 @@ import MultiLineChart from "../charts/MultiLineChart";
 import SimpleBarChart from "../charts/SimpleBarChart";
 import GraphicDashboard from "./GraphicDashboard";
 import GraphicIconDashboard from "./GraphicIconDashboard";
-import { DashboardDataProps } from "./ObjectiveSec";
-import ObjectiveSec from "./ObjectiveSec";
+import ObjectiveSec, { DashboardDataProps } from "./ObjectiveSec";
 import ValueNumberDashboard from "./ValueNumberDashboard";
 
 interface secondOptionsDataItem {
@@ -102,11 +102,11 @@ const SecDashboard = ({
     router.push("/dashboard/project-list");
   };
 
-  useEffect(() => {
+  useOnMount(() => {
     if (data?.tableData) {
       setToggleValue(1);
     }
-  }, []);
+  });
 
   useEffect(() => {
     if (dataForChart && dataForChart?.message === "Job dispatched") {
@@ -120,7 +120,7 @@ const SecDashboard = ({
       const data = getRestorationGoalResumeData(dataForChart);
       setRestorationGoalResume(data);
     }
-  }, [dataForChart, toggleValue]);
+  }, [chartType, dataForChart, isProjectView, toggleValue]);
 
   return (
     <div className={className}>

--- a/src/pages/dashboard/index.page.tsx
+++ b/src/pages/dashboard/index.page.tsx
@@ -13,6 +13,7 @@ import { logout } from "@/connections/Login";
 import { useMyUser } from "@/connections/User";
 import { CHART_TYPES, JOBS_CREATED_CHART_TYPE, ORGANIZATIONS_TYPES, TEXT_TYPES } from "@/constants/dashboardConsts";
 import { useDashboardContext } from "@/context/dashboard.provider";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import {
   formatLabelsVolunteers,
   getFrameworkName,
@@ -122,17 +123,16 @@ const Dashboard = () => {
 
   useEffect(() => {
     setLastUpdatedAt?.(totalSectionHeader?.last_updated_at);
-  }, [totalSectionHeader]);
+  }, [setLastUpdatedAt, totalSectionHeader]);
 
-  useEffect(() => {
+  useValueChanged(generalBbox, () => {
     if (generalBbox) {
       setCurrentBbox(generalBbox);
     }
-  }, [generalBbox]);
+  });
 
-  useEffect(() => {
-    refetchTotalSectionHeader();
-  }, [filters]);
+  useValueChanged(filters, refetchTotalSectionHeader);
+
   const COLUMN_ACTIVE_PROGRAMME = [
     {
       header: "Country",

--- a/src/pages/project-pitches/components/tabs/PitchOverviewTab.tsx
+++ b/src/pages/project-pitches/components/tabs/PitchOverviewTab.tsx
@@ -1,5 +1,5 @@
 import { useT } from "@transifex/react";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useState } from "react";
 
 import Accordion from "@/components/elements/Accordion/Accordion";
 import Button from "@/components/elements/Button/Button";
@@ -21,11 +21,13 @@ import { useModalContext } from "@/context/modal.provider";
 import { fetchGetV2TerrafundPolygonBboxUuid, useGetV2TerrafundProjectPolygon } from "@/generated/apiComponents";
 import { ProjectPitchRead } from "@/generated/apiSchemas";
 import { useDate } from "@/hooks/useDate";
+import { useValueChanged } from "@/hooks/useValueChanged";
 import PitchEditModal from "@/pages/project-pitches/components/PitchEditModal";
 import TabContainer from "@/pages/project-pitches/components/tabs/TabContainer";
 import { UploadedFile } from "@/types/common";
 import { notEmpty } from "@/utils/array";
 import { formatOptionsList } from "@/utils/options";
+
 interface PitchOverviewTabProps {
   pitch: ProjectPitchRead;
 }
@@ -62,17 +64,14 @@ const PitchOverviewTab = ({ pitch }: PitchOverviewTabProps) => {
     }
   };
 
-  useEffect(() => {
-    const getDataProjectPolygon = async () => {
-      if (projectPolygon?.project_polygon) {
-        setBbboxAndZoom();
-        setPolygonDataMap({ [FORM_POLYGONS]: [projectPolygon?.project_polygon?.poly_uuid] });
-      } else {
-        setPolygonDataMap({ [FORM_POLYGONS]: [] });
-      }
-    };
-    getDataProjectPolygon();
-  }, [projectPolygon]);
+  useValueChanged(projectPolygon, async () => {
+    if (projectPolygon?.project_polygon) {
+      setBbboxAndZoom();
+      setPolygonDataMap({ [FORM_POLYGONS]: [projectPolygon?.project_polygon?.poly_uuid] });
+    } else {
+      setPolygonDataMap({ [FORM_POLYGONS]: [] });
+    }
+  });
 
   return (
     <TabContainer>

--- a/src/pages/project/[uuid]/tabs/AuditLog.tsx
+++ b/src/pages/project/[uuid]/tabs/AuditLog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { When } from "react-if";
 
 import AuditLogSiteTabSelection from "@/admin/components/ResourceTabs/AuditLogTab/components/AuditLogSiteTabSelection";
@@ -12,6 +12,7 @@ import PageColumn from "@/components/extensive/PageElements/Column/PageColumn";
 import PageRow from "@/components/extensive/PageElements/Row/PageRow";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
 import useAuditLogActions from "@/hooks/AuditStatus/useAuditLogActions";
+import { useValueChanged } from "@/hooks/useValueChanged";
 
 interface ReportingTasksProps {
   project: any;
@@ -47,10 +48,10 @@ const AuditLog = ({ label, project, refresh: refreshProject, enableChangeStatus,
     entityLevel: AuditLogButtonStates.PROJECT
   });
 
-  useEffect(() => {
+  useValueChanged(buttonToggle, () => {
     refetch();
     loadEntityList();
-  }, [buttonToggle]);
+  });
 
   return (
     <PageBody>

--- a/src/pages/site/[uuid]/components/SiteArea.tsx
+++ b/src/pages/site/[uuid]/components/SiteArea.tsx
@@ -1,5 +1,5 @@
 import { useT } from "@transifex/react";
-import { Dispatch, SetStateAction, useEffect } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { When } from "react-if";
 
 import Button from "@/components/elements/Button/Button";
@@ -10,6 +10,7 @@ import { useMapAreaContext } from "@/context/mapArea.provider";
 import { useNotificationContext } from "@/context/notification.provider";
 import { useGetV2SitePolygonUuidVersions, usePutV2SitePolygonUuidMakeActive } from "@/generated/apiComponents";
 import { SitePolygonsDataResponse } from "@/generated/apiSchemas";
+import { useValueChanged } from "@/hooks/useValueChanged";
 
 interface SiteAreaProps {
   sites: any;
@@ -74,11 +75,11 @@ const SiteArea = ({ sites, refetch }: SiteAreaProps) => {
     openNotification("warning", t("Warning!"), t("Polygon version is already active"));
   };
 
-  useEffect(() => {
+  useValueChanged(shouldRefetchPolygonVersions, () => {
     if (shouldRefetchPolygonVersions) {
       refetchPolygonVersions();
     }
-  }, [shouldRefetchPolygonVersions]);
+  });
 
   const convertText = (text: string) => {
     return text?.replace(/-/g, " ");

--- a/src/pages/site/[uuid]/tabs/AuditLog.tsx
+++ b/src/pages/site/[uuid]/tabs/AuditLog.tsx
@@ -1,6 +1,6 @@
 import { useT } from "@transifex/react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { When } from "react-if";
 
 import AuditLogSiteTabSelection from "@/admin/components/ResourceTabs/AuditLogTab/components/AuditLogSiteTabSelection";
@@ -14,6 +14,7 @@ import PageColumn from "@/components/extensive/PageElements/Column/PageColumn";
 import PageRow from "@/components/extensive/PageElements/Row/PageRow";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
 import useAuditLogActions from "@/hooks/AuditStatus/useAuditLogActions";
+import { useValueChanged } from "@/hooks/useValueChanged";
 
 interface ReportingTasksProps {
   site: any;
@@ -50,10 +51,10 @@ const AuditLog = ({ label, site, refresh: refreshSite, enableChangeStatus, ...re
     entityLevel: AuditLogButtonStates.SITE
   });
 
-  useEffect(() => {
+  useValueChanged(buttonToggle, () => {
     refetch();
     loadEntityList();
-  }, [buttonToggle]);
+  });
 
   return (
     <PageBody>

--- a/src/pages/site/[uuid]/tabs/Overview.tsx
+++ b/src/pages/site/[uuid]/tabs/Overview.tsx
@@ -110,7 +110,7 @@ const SiteOverviewTab = ({ site, refetch: refetchEntity }: SiteOverviewTabProps)
     if (site.project?.uuid) {
       checkIsMonitoringPartner(site.project?.uuid);
     }
-  }, [site]);
+  }, [checkIsMonitoringPartner, setSiteData, site]);
 
   useEffect(() => {
     if (files && files.length > 0 && saveFlags) {
@@ -118,6 +118,7 @@ const SiteOverviewTab = ({ site, refetch: refetchEntity }: SiteOverviewTabProps)
       setSaveFlags(false);
       closeModal(ModalId.ADD_POLYGONS);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files, saveFlags]);
 
   const getFileType = (file: UploadedFile) => {


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1715

This is a big refactor. I believe that I kept the intention behind each use of useEffect, useMemo and useCallback the same and improved things along the way.

Two general patterns I noticed:
* Sometimes, a single parameter was passed in the dependencies to `useEffect`, meaning that the effect should only execute if that dep changes. In cases like this, `useValueChanged` will let you avoid the linter problem and make the intention of your code clearer.
* At other times, an empty array was passed to `useEffect` meaning that it should only execute when the component mounts and never again. We have a custom hook for this as well: `useOnMount`. This also makes the intention of the code clearer while avoiding the linter rule.

There were a couple of other patterns I noted, especially in map components, but those ones are generally way too big and complicated to follow for me to extract a good pattern. Mainly just know this: if you're finding that your component is using many instances of useEffect, you're probably in anti-pattern town. Especially if you find yourself setting effects that depend on changing values from useState hooks. This is going to lead to a lot of rerenders and gradual state changes of the overall component that are both bad for performance and bad for user experience. I hope that some day we can revisit the these incredibly complicated mapping components and get them into a better state, but this refactor is already complicated enough; I didn't want to bog it down with further investigations along those lines.