### PR TITLE
[TM-1810] Memoize the source data so we don't update on every render.

### DIFF
--- a/src/admin/components/EntityEdit/EntityEdit.tsx
+++ b/src/admin/components/EntityEdit/EntityEdit.tsx
@@ -58,10 +58,11 @@ export const EntityEdit = () => {
   const framework = formData?.form?.framework_key as Framework;
   const formSteps = useGetCustomFormSteps(formData.form, entity, framework);
 
-  const defaultValues = useNormalizedFormDefaultValue(
-    defaults(formData?.update_request?.content ?? {}, formData?.answers),
-    formSteps
+  const sourceData = useMemo(
+    () => defaults(formData?.update_request?.content ?? {}, formData?.answers),
+    [formData?.answers, formData?.update_request?.content]
   );
+  const defaultValues = useNormalizedFormDefaultValue(sourceData, formSteps);
 
   // @ts-ignore
   const { form_title: title } = formData;

--- a/src/pages/entity/[entityName]/edit/[uuid]/EditEntityForm.tsx
+++ b/src/pages/entity/[entityName]/edit/[uuid]/EditEntityForm.tsx
@@ -60,11 +60,11 @@ const EditEntityForm = ({ entityName, entityUUID, entity, formData }: EditEntity
     mode?.includes("provide-feedback") ? feedbackFields : undefined
   );
 
-  const defaultValues = useNormalizedFormDefaultValue(
-    defaults(formData?.update_request?.content ?? {}, formData?.answers),
-    formSteps,
-    entity.migrated
+  const sourceData = useMemo(
+    () => defaults(formData?.update_request?.content ?? {}, formData?.answers),
+    [formData?.answers, formData?.update_request?.content]
   );
+  const defaultValues = useNormalizedFormDefaultValue(sourceData, formSteps, entity.migrated);
 
   const reportingWindow = useReportingWindow(entity?.due_at);
   const formTitle =


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1810

I added the call to `defaults()` in a recent web PR so that update requests would update with new form field values when a form is changed. However, calling defaults() every render was causing the source data to change for `useNormalizedFormDefaultValue`, and that source data is an input to its own useMemo dependency array, so this was causing forms to lose data while the user is typing (see loom on attached ticket).