### PR TITLE
[TM-1863] Improve Amplify builds

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,6 +3,7 @@ frontend:
   phases:
     preBuild:
       commands:
+        - echo "Using node version `node -v`"
         - yarn install
     build:
       commands:

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,20 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - nvm install `cat .nvmrc`
+        - nvm use
+        - yarn install
+    build:
+      commands:
+        - nvm use
+        - yarn run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - .next/cache/**/*
+      - node_modules/**/*

--- a/amplify.yml
+++ b/amplify.yml
@@ -3,12 +3,9 @@ frontend:
   phases:
     preBuild:
       commands:
-        - nvm install `cat .nvmrc`
-        - nvm use
         - yarn install
     build:
       commands:
-        - nvm use
         - yarn run build
   artifacts:
     baseDirectory: .next

--- a/next.config.js
+++ b/next.config.js
@@ -31,7 +31,10 @@ const nextConfig = {
 
     return config;
   },
-  transpilePackages: ["mapbox-gl-draw-circle"]
+  transpilePackages: ["mapbox-gl-draw-circle"],
+  eslint: {
+    ignoreDuringBuilds: true
+  }
 };
 
 /** @type {import('@sentry/nextjs').SentryWebpackPluginOptions} */

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    "tailwindcss/nesting": {},
     tailwindcss: {},
     autoprefixer: {},
     ...(process.env.NODE_ENV === "production" ? { cssnano: {} } : {})


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1863

The main things here were eliminating some build errors during the next build. I don't think that actually fixed the problem though.  The other thing I did was update Amplify to use a build image with the same node version we have configured locally (`20.11.1`), which does seem to have addressed the problem. The default image on Amplify appears to have been using Node 18