### PR TITLE
[TM-2009] if no uuid provided then no-op

### DIFF
--- a/src/connections/Entity.ts
+++ b/src/connections/Entity.ts
@@ -156,6 +156,9 @@ const createGetEntityConnection = <T extends EntityDtoType, U extends EntityUpda
   entityName: U["type"]
 ): Connection<EntityConnection<T, U>, EntityConnectionProps> => ({
   load: (connection, props) => {
+    if (!props.uuid || props.uuid.trim() === "") {
+      return;
+    }
     if (!entityIsLoaded(true)(connection, props)) entityGet(specificEntityParams(entityName, props.uuid));
   },
 


### PR DESCRIPTION
This adds to connection a no-op case when there is no uuid provided. 
the useFullEntity previously if no uuid provided, returns multiple entities ( not sure if all ).

