### PR TITLE
[TM-2040] prevent unnecesary call for bouunding box

### DIFF
--- a/src/connections/BoundingBox.ts
+++ b/src/connections/BoundingBox.ts
@@ -37,7 +37,11 @@ const boundingBoxLoadFailed = (props: BoundingBoxProps) => (store: ApiDataStore)
 };
 
 const hasValidParams = ({ polygonUuid, siteUuid, projectUuid, landscapes, country }: BoundingBoxProps): boolean =>
-  polygonUuid != null || siteUuid != null || projectUuid != null || (landscapes?.length ?? 0) > 0 || country != null;
+  (polygonUuid != null && polygonUuid !== "") ||
+  (siteUuid != null && siteUuid !== "") ||
+  (projectUuid != null && projectUuid !== "") ||
+  (landscapes?.length ?? 0) > 0 ||
+  (country != null && country !== "");
 
 const getQueryParams = (props: BoundingBoxProps) => {
   const { polygonUuid, siteUuid, projectUuid, landscapes, country } = props;


### PR DESCRIPTION
Make invalid params empty string. 
This was leading to console errors that we want to avoid.