### PR TITLE
[TM-2211] Fix the login form so that it can be submitted again after a failure.

### DIFF
--- a/openapi-codegen.config.ts
+++ b/openapi-codegen.config.ts
@@ -445,11 +445,27 @@ const createSelectorNodes = ({
   name: string;
   includeIndexMeta: boolean;
 }) => {
-  const nodes: ts.Node[] = [];
+  const urlNodeName = _.snakeCase(`${name}_url`).toUpperCase();
+  const nodes: ts.Node[] = [
+    f.createVariableStatement(
+      [f.createModifier(ts.SyntaxKind.ExportKeyword)],
+      f.createVariableDeclarationList(
+        [
+          f.createVariableDeclaration(
+            f.createIdentifier(urlNodeName),
+            undefined,
+            undefined,
+            f.createStringLiteral(camelizedPathParams(url))
+          )
+        ],
+        ts.NodeFlags.Const
+      )
+    )
+  ];
 
   const createSelectorNode = (fnName: string) => {
     const selectorArguments: ts.ObjectLiteralElementLike[] = [
-      f.createPropertyAssignment(f.createIdentifier("url"), f.createStringLiteral(camelizedPathParams(url)))
+      f.createPropertyAssignment(f.createIdentifier("url"), f.createIdentifier(urlNodeName))
     ];
     if (fnName === "indexMeta") {
       selectorArguments.push(f.createShorthandPropertyAssignment("resource"));

--- a/src/generated/v3/dashboardService/dashboardServiceSelectors.ts
+++ b/src/generated/v3/dashboardService/dashboardServiceSelectors.ts
@@ -6,30 +6,34 @@ import {
   GetTreeRestorationGoalVariables
 } from "./dashboardServiceComponents";
 
+export const GET_TOTAL_SECTION_HEADERS_URL = "/dashboard/v3/totalSectionHeaders";
+
 export const getTotalSectionHeadersIsFetching = (variables: Omit<GetTotalSectionHeadersVariables, "body">) =>
   isFetchingSelector<GetTotalSectionHeadersQueryParams, {}>({
-    url: "/dashboard/v3/totalSectionHeaders",
+    url: GET_TOTAL_SECTION_HEADERS_URL,
     method: "get",
     ...variables
   });
 
 export const getTotalSectionHeadersFetchFailed = (variables: Omit<GetTotalSectionHeadersVariables, "body">) =>
   fetchFailedSelector<GetTotalSectionHeadersQueryParams, {}>({
-    url: "/dashboard/v3/totalSectionHeaders",
+    url: GET_TOTAL_SECTION_HEADERS_URL,
     method: "get",
     ...variables
   });
 
+export const GET_TREE_RESTORATION_GOAL_URL = "/dashboard/v3/treeRestorationGoal";
+
 export const getTreeRestorationGoalIsFetching = (variables: Omit<GetTreeRestorationGoalVariables, "body">) =>
   isFetchingSelector<GetTreeRestorationGoalQueryParams, {}>({
-    url: "/dashboard/v3/treeRestorationGoal",
+    url: GET_TREE_RESTORATION_GOAL_URL,
     method: "get",
     ...variables
   });
 
 export const getTreeRestorationGoalFetchFailed = (variables: Omit<GetTreeRestorationGoalVariables, "body">) =>
   fetchFailedSelector<GetTreeRestorationGoalQueryParams, {}>({
-    url: "/dashboard/v3/treeRestorationGoal",
+    url: GET_TREE_RESTORATION_GOAL_URL,
     method: "get",
     ...variables
   });

--- a/src/generated/v3/entityService/entityServiceSelectors.ts
+++ b/src/generated/v3/entityService/entityServiceSelectors.ts
@@ -39,116 +39,93 @@ import {
   EntityAssociationIndexVariables
 } from "./entityServiceComponents";
 
+export const PROJECT_PITCH_INDEX_URL = "/entities/v3/projectPitches";
+
 export const projectPitchIndexIsFetching = (variables: Omit<ProjectPitchIndexVariables, "body">) =>
-  isFetchingSelector<ProjectPitchIndexQueryParams, {}>({
-    url: "/entities/v3/projectPitches",
-    method: "get",
-    ...variables
-  });
+  isFetchingSelector<ProjectPitchIndexQueryParams, {}>({ url: PROJECT_PITCH_INDEX_URL, method: "get", ...variables });
 
 export const projectPitchIndexFetchFailed = (variables: Omit<ProjectPitchIndexVariables, "body">) =>
-  fetchFailedSelector<ProjectPitchIndexQueryParams, {}>({
-    url: "/entities/v3/projectPitches",
-    method: "get",
-    ...variables
-  });
+  fetchFailedSelector<ProjectPitchIndexQueryParams, {}>({ url: PROJECT_PITCH_INDEX_URL, method: "get", ...variables });
 
 export const projectPitchIndexIndexMeta = (
   resource: ResourceType,
   variables: Omit<ProjectPitchIndexVariables, "body">
-) =>
-  indexMetaSelector<ProjectPitchIndexQueryParams, {}>({ url: "/entities/v3/projectPitches", resource, ...variables });
+) => indexMetaSelector<ProjectPitchIndexQueryParams, {}>({ url: PROJECT_PITCH_INDEX_URL, resource, ...variables });
+
+export const PROJECT_PITCH_GET_URL = "/entities/v3/projectPitches/{uuid}";
 
 export const projectPitchGetIsFetching = (variables: Omit<ProjectPitchGetVariables, "body">) =>
-  isFetchingSelector<{}, ProjectPitchGetPathParams>({
-    url: "/entities/v3/projectPitches/{uuid}",
-    method: "get",
-    ...variables
-  });
+  isFetchingSelector<{}, ProjectPitchGetPathParams>({ url: PROJECT_PITCH_GET_URL, method: "get", ...variables });
 
 export const projectPitchGetFetchFailed = (variables: Omit<ProjectPitchGetVariables, "body">) =>
-  fetchFailedSelector<{}, ProjectPitchGetPathParams>({
-    url: "/entities/v3/projectPitches/{uuid}",
-    method: "get",
-    ...variables
-  });
+  fetchFailedSelector<{}, ProjectPitchGetPathParams>({ url: PROJECT_PITCH_GET_URL, method: "get", ...variables });
+
+export const IMPACT_STORY_INDEX_URL = "/entities/v3/impactStories";
 
 export const impactStoryIndexIsFetching = (variables: Omit<ImpactStoryIndexVariables, "body">) =>
-  isFetchingSelector<ImpactStoryIndexQueryParams, {}>({
-    url: "/entities/v3/impactStories",
-    method: "get",
-    ...variables
-  });
+  isFetchingSelector<ImpactStoryIndexQueryParams, {}>({ url: IMPACT_STORY_INDEX_URL, method: "get", ...variables });
 
 export const impactStoryIndexFetchFailed = (variables: Omit<ImpactStoryIndexVariables, "body">) =>
-  fetchFailedSelector<ImpactStoryIndexQueryParams, {}>({
-    url: "/entities/v3/impactStories",
-    method: "get",
-    ...variables
-  });
+  fetchFailedSelector<ImpactStoryIndexQueryParams, {}>({ url: IMPACT_STORY_INDEX_URL, method: "get", ...variables });
 
 export const impactStoryIndexIndexMeta = (resource: ResourceType, variables: Omit<ImpactStoryIndexVariables, "body">) =>
-  indexMetaSelector<ImpactStoryIndexQueryParams, {}>({ url: "/entities/v3/impactStories", resource, ...variables });
+  indexMetaSelector<ImpactStoryIndexQueryParams, {}>({ url: IMPACT_STORY_INDEX_URL, resource, ...variables });
+
+export const IMPACT_STORY_GET_URL = "/entities/v3/impactStories/{uuid}";
 
 export const impactStoryGetIsFetching = (variables: Omit<ImpactStoryGetVariables, "body">) =>
-  isFetchingSelector<{}, ImpactStoryGetPathParams>({
-    url: "/entities/v3/impactStories/{uuid}",
-    method: "get",
-    ...variables
-  });
+  isFetchingSelector<{}, ImpactStoryGetPathParams>({ url: IMPACT_STORY_GET_URL, method: "get", ...variables });
 
 export const impactStoryGetFetchFailed = (variables: Omit<ImpactStoryGetVariables, "body">) =>
-  fetchFailedSelector<{}, ImpactStoryGetPathParams>({
-    url: "/entities/v3/impactStories/{uuid}",
-    method: "get",
-    ...variables
-  });
+  fetchFailedSelector<{}, ImpactStoryGetPathParams>({ url: IMPACT_STORY_GET_URL, method: "get", ...variables });
+
+export const TASK_INDEX_URL = "/entities/v3/tasks";
 
 export const taskIndexIsFetching = (variables: Omit<TaskIndexVariables, "body">) =>
-  isFetchingSelector<TaskIndexQueryParams, {}>({ url: "/entities/v3/tasks", method: "get", ...variables });
+  isFetchingSelector<TaskIndexQueryParams, {}>({ url: TASK_INDEX_URL, method: "get", ...variables });
 
 export const taskIndexFetchFailed = (variables: Omit<TaskIndexVariables, "body">) =>
-  fetchFailedSelector<TaskIndexQueryParams, {}>({ url: "/entities/v3/tasks", method: "get", ...variables });
+  fetchFailedSelector<TaskIndexQueryParams, {}>({ url: TASK_INDEX_URL, method: "get", ...variables });
 
 export const taskIndexIndexMeta = (resource: ResourceType, variables: Omit<TaskIndexVariables, "body">) =>
-  indexMetaSelector<TaskIndexQueryParams, {}>({ url: "/entities/v3/tasks", resource, ...variables });
+  indexMetaSelector<TaskIndexQueryParams, {}>({ url: TASK_INDEX_URL, resource, ...variables });
+
+export const TASK_GET_URL = "/entities/v3/tasks/{uuid}";
 
 export const taskGetIsFetching = (variables: Omit<TaskGetVariables, "body">) =>
-  isFetchingSelector<{}, TaskGetPathParams>({ url: "/entities/v3/tasks/{uuid}", method: "get", ...variables });
+  isFetchingSelector<{}, TaskGetPathParams>({ url: TASK_GET_URL, method: "get", ...variables });
 
 export const taskGetFetchFailed = (variables: Omit<TaskGetVariables, "body">) =>
-  fetchFailedSelector<{}, TaskGetPathParams>({ url: "/entities/v3/tasks/{uuid}", method: "get", ...variables });
+  fetchFailedSelector<{}, TaskGetPathParams>({ url: TASK_GET_URL, method: "get", ...variables });
+
+export const TASK_UPDATE_URL = "/entities/v3/tasks/{uuid}";
 
 export const taskUpdateIsFetching = (variables: Omit<TaskUpdateVariables, "body">) =>
-  isFetchingSelector<{}, TaskUpdatePathParams>({ url: "/entities/v3/tasks/{uuid}", method: "patch", ...variables });
+  isFetchingSelector<{}, TaskUpdatePathParams>({ url: TASK_UPDATE_URL, method: "patch", ...variables });
 
 export const taskUpdateFetchFailed = (variables: Omit<TaskUpdateVariables, "body">) =>
-  fetchFailedSelector<{}, TaskUpdatePathParams>({ url: "/entities/v3/tasks/{uuid}", method: "patch", ...variables });
+  fetchFailedSelector<{}, TaskUpdatePathParams>({ url: TASK_UPDATE_URL, method: "patch", ...variables });
+
+export const UPLOAD_FILE_URL = "/entities/v3/files/{entity}/{uuid}/{collection}";
 
 export const uploadFileIsFetching = (variables: Omit<UploadFileVariables, "body">) =>
-  isFetchingSelector<{}, UploadFilePathParams>({
-    url: "/entities/v3/files/{entity}/{uuid}/{collection}",
-    method: "post",
-    ...variables
-  });
+  isFetchingSelector<{}, UploadFilePathParams>({ url: UPLOAD_FILE_URL, method: "post", ...variables });
 
 export const uploadFileFetchFailed = (variables: Omit<UploadFileVariables, "body">) =>
-  fetchFailedSelector<{}, UploadFilePathParams>({
-    url: "/entities/v3/files/{entity}/{uuid}/{collection}",
-    method: "post",
-    ...variables
-  });
+  fetchFailedSelector<{}, UploadFilePathParams>({ url: UPLOAD_FILE_URL, method: "post", ...variables });
+
+export const TREE_SCIENTIFIC_NAMES_SEARCH_URL = "/trees/v3/scientificNames";
 
 export const treeScientificNamesSearchIsFetching = (variables: Omit<TreeScientificNamesSearchVariables, "body">) =>
   isFetchingSelector<TreeScientificNamesSearchQueryParams, {}>({
-    url: "/trees/v3/scientificNames",
+    url: TREE_SCIENTIFIC_NAMES_SEARCH_URL,
     method: "get",
     ...variables
   });
 
 export const treeScientificNamesSearchFetchFailed = (variables: Omit<TreeScientificNamesSearchVariables, "body">) =>
   fetchFailedSelector<TreeScientificNamesSearchQueryParams, {}>({
-    url: "/trees/v3/scientificNames",
+    url: TREE_SCIENTIFIC_NAMES_SEARCH_URL,
     method: "get",
     ...variables
   });
@@ -158,123 +135,111 @@ export const treeScientificNamesSearchIndexMeta = (
   variables: Omit<TreeScientificNamesSearchVariables, "body">
 ) =>
   indexMetaSelector<TreeScientificNamesSearchQueryParams, {}>({
-    url: "/trees/v3/scientificNames",
+    url: TREE_SCIENTIFIC_NAMES_SEARCH_URL,
     resource,
     ...variables
   });
 
+export const ESTABLISHMENT_TREES_FIND_URL = "/trees/v3/establishments/{entity}/{uuid}";
+
 export const establishmentTreesFindIsFetching = (variables: Omit<EstablishmentTreesFindVariables, "body">) =>
   isFetchingSelector<{}, EstablishmentTreesFindPathParams>({
-    url: "/trees/v3/establishments/{entity}/{uuid}",
+    url: ESTABLISHMENT_TREES_FIND_URL,
     method: "get",
     ...variables
   });
 
 export const establishmentTreesFindFetchFailed = (variables: Omit<EstablishmentTreesFindVariables, "body">) =>
   fetchFailedSelector<{}, EstablishmentTreesFindPathParams>({
-    url: "/trees/v3/establishments/{entity}/{uuid}",
+    url: ESTABLISHMENT_TREES_FIND_URL,
     method: "get",
     ...variables
   });
 
+export const TREE_REPORT_COUNTS_FIND_URL = "/trees/v3/reportCounts/{entity}/{uuid}";
+
 export const treeReportCountsFindIsFetching = (variables: Omit<TreeReportCountsFindVariables, "body">) =>
   isFetchingSelector<{}, TreeReportCountsFindPathParams>({
-    url: "/trees/v3/reportCounts/{entity}/{uuid}",
+    url: TREE_REPORT_COUNTS_FIND_URL,
     method: "get",
     ...variables
   });
 
 export const treeReportCountsFindFetchFailed = (variables: Omit<TreeReportCountsFindVariables, "body">) =>
   fetchFailedSelector<{}, TreeReportCountsFindPathParams>({
-    url: "/trees/v3/reportCounts/{entity}/{uuid}",
+    url: TREE_REPORT_COUNTS_FIND_URL,
     method: "get",
     ...variables
   });
+
+export const DEMOGRAPHICS_INDEX_URL = "/entities/v3/demographics";
 
 export const demographicsIndexIsFetching = (variables: Omit<DemographicsIndexVariables, "body">) =>
-  isFetchingSelector<DemographicsIndexQueryParams, {}>({
-    url: "/entities/v3/demographics",
-    method: "get",
-    ...variables
-  });
+  isFetchingSelector<DemographicsIndexQueryParams, {}>({ url: DEMOGRAPHICS_INDEX_URL, method: "get", ...variables });
 
 export const demographicsIndexFetchFailed = (variables: Omit<DemographicsIndexVariables, "body">) =>
-  fetchFailedSelector<DemographicsIndexQueryParams, {}>({
-    url: "/entities/v3/demographics",
-    method: "get",
-    ...variables
-  });
+  fetchFailedSelector<DemographicsIndexQueryParams, {}>({ url: DEMOGRAPHICS_INDEX_URL, method: "get", ...variables });
 
 export const demographicsIndexIndexMeta = (
   resource: ResourceType,
   variables: Omit<DemographicsIndexVariables, "body">
-) => indexMetaSelector<DemographicsIndexQueryParams, {}>({ url: "/entities/v3/demographics", resource, ...variables });
+) => indexMetaSelector<DemographicsIndexQueryParams, {}>({ url: DEMOGRAPHICS_INDEX_URL, resource, ...variables });
+
+export const ENTITY_INDEX_URL = "/entities/v3/{entity}";
 
 export const entityIndexIsFetching = (variables: Omit<EntityIndexVariables, "body">) =>
   isFetchingSelector<EntityIndexQueryParams, EntityIndexPathParams>({
-    url: "/entities/v3/{entity}",
+    url: ENTITY_INDEX_URL,
     method: "get",
     ...variables
   });
 
 export const entityIndexFetchFailed = (variables: Omit<EntityIndexVariables, "body">) =>
   fetchFailedSelector<EntityIndexQueryParams, EntityIndexPathParams>({
-    url: "/entities/v3/{entity}",
+    url: ENTITY_INDEX_URL,
     method: "get",
     ...variables
   });
 
 export const entityIndexIndexMeta = (resource: ResourceType, variables: Omit<EntityIndexVariables, "body">) =>
-  indexMetaSelector<EntityIndexQueryParams, EntityIndexPathParams>({
-    url: "/entities/v3/{entity}",
-    resource,
-    ...variables
-  });
+  indexMetaSelector<EntityIndexQueryParams, EntityIndexPathParams>({ url: ENTITY_INDEX_URL, resource, ...variables });
+
+export const ENTITY_GET_URL = "/entities/v3/{entity}/{uuid}";
 
 export const entityGetIsFetching = (variables: Omit<EntityGetVariables, "body">) =>
-  isFetchingSelector<{}, EntityGetPathParams>({ url: "/entities/v3/{entity}/{uuid}", method: "get", ...variables });
+  isFetchingSelector<{}, EntityGetPathParams>({ url: ENTITY_GET_URL, method: "get", ...variables });
 
 export const entityGetFetchFailed = (variables: Omit<EntityGetVariables, "body">) =>
-  fetchFailedSelector<{}, EntityGetPathParams>({ url: "/entities/v3/{entity}/{uuid}", method: "get", ...variables });
+  fetchFailedSelector<{}, EntityGetPathParams>({ url: ENTITY_GET_URL, method: "get", ...variables });
+
+export const ENTITY_DELETE_URL = "/entities/v3/{entity}/{uuid}";
 
 export const entityDeleteIsFetching = (variables: Omit<EntityDeleteVariables, "body">) =>
-  isFetchingSelector<{}, EntityDeletePathParams>({
-    url: "/entities/v3/{entity}/{uuid}",
-    method: "delete",
-    ...variables
-  });
+  isFetchingSelector<{}, EntityDeletePathParams>({ url: ENTITY_DELETE_URL, method: "delete", ...variables });
 
 export const entityDeleteFetchFailed = (variables: Omit<EntityDeleteVariables, "body">) =>
-  fetchFailedSelector<{}, EntityDeletePathParams>({
-    url: "/entities/v3/{entity}/{uuid}",
-    method: "delete",
-    ...variables
-  });
+  fetchFailedSelector<{}, EntityDeletePathParams>({ url: ENTITY_DELETE_URL, method: "delete", ...variables });
+
+export const ENTITY_UPDATE_URL = "/entities/v3/{entity}/{uuid}";
 
 export const entityUpdateIsFetching = (variables: Omit<EntityUpdateVariables, "body">) =>
-  isFetchingSelector<{}, EntityUpdatePathParams>({
-    url: "/entities/v3/{entity}/{uuid}",
-    method: "patch",
-    ...variables
-  });
+  isFetchingSelector<{}, EntityUpdatePathParams>({ url: ENTITY_UPDATE_URL, method: "patch", ...variables });
 
 export const entityUpdateFetchFailed = (variables: Omit<EntityUpdateVariables, "body">) =>
-  fetchFailedSelector<{}, EntityUpdatePathParams>({
-    url: "/entities/v3/{entity}/{uuid}",
-    method: "patch",
-    ...variables
-  });
+  fetchFailedSelector<{}, EntityUpdatePathParams>({ url: ENTITY_UPDATE_URL, method: "patch", ...variables });
+
+export const ENTITY_ASSOCIATION_INDEX_URL = "/entities/v3/{entity}/{uuid}/{association}";
 
 export const entityAssociationIndexIsFetching = (variables: Omit<EntityAssociationIndexVariables, "body">) =>
   isFetchingSelector<EntityAssociationIndexQueryParams, EntityAssociationIndexPathParams>({
-    url: "/entities/v3/{entity}/{uuid}/{association}",
+    url: ENTITY_ASSOCIATION_INDEX_URL,
     method: "get",
     ...variables
   });
 
 export const entityAssociationIndexFetchFailed = (variables: Omit<EntityAssociationIndexVariables, "body">) =>
   fetchFailedSelector<EntityAssociationIndexQueryParams, EntityAssociationIndexPathParams>({
-    url: "/entities/v3/{entity}/{uuid}/{association}",
+    url: ENTITY_ASSOCIATION_INDEX_URL,
     method: "get",
     ...variables
   });
@@ -284,7 +249,7 @@ export const entityAssociationIndexIndexMeta = (
   variables: Omit<EntityAssociationIndexVariables, "body">
 ) =>
   indexMetaSelector<EntityAssociationIndexQueryParams, EntityAssociationIndexPathParams>({
-    url: "/entities/v3/{entity}/{uuid}/{association}",
+    url: ENTITY_ASSOCIATION_INDEX_URL,
     resource,
     ...variables
   });

--- a/src/generated/v3/jobService/jobServiceSelectors.ts
+++ b/src/generated/v3/jobService/jobServiceSelectors.ts
@@ -2,33 +2,25 @@ import { isFetchingSelector, fetchFailedSelector, indexMetaSelector } from "../u
 import { ResourceType } from "@/store/apiSlice";
 import { DelayedJobsFindPathParams, DelayedJobsFindVariables } from "./jobServiceComponents";
 
-export const listDelayedJobsIsFetching = isFetchingSelector<{}, {}>({ url: "/jobs/v3/delayedJobs", method: "get" });
+export const LIST_DELAYED_JOBS_URL = "/jobs/v3/delayedJobs";
 
-export const listDelayedJobsFetchFailed = fetchFailedSelector<{}, {}>({ url: "/jobs/v3/delayedJobs", method: "get" });
+export const listDelayedJobsIsFetching = isFetchingSelector<{}, {}>({ url: LIST_DELAYED_JOBS_URL, method: "get" });
+
+export const listDelayedJobsFetchFailed = fetchFailedSelector<{}, {}>({ url: LIST_DELAYED_JOBS_URL, method: "get" });
 
 export const listDelayedJobsIndexMeta = (resource: ResourceType) =>
-  indexMetaSelector<{}, {}>({ url: "/jobs/v3/delayedJobs", resource });
+  indexMetaSelector<{}, {}>({ url: LIST_DELAYED_JOBS_URL, resource });
+
+export const DELAYED_JOBS_FIND_URL = "/jobs/v3/delayedJobs/{uuid}";
 
 export const delayedJobsFindIsFetching = (variables: Omit<DelayedJobsFindVariables, "body">) =>
-  isFetchingSelector<{}, DelayedJobsFindPathParams>({
-    url: "/jobs/v3/delayedJobs/{uuid}",
-    method: "get",
-    ...variables
-  });
+  isFetchingSelector<{}, DelayedJobsFindPathParams>({ url: DELAYED_JOBS_FIND_URL, method: "get", ...variables });
 
 export const delayedJobsFindFetchFailed = (variables: Omit<DelayedJobsFindVariables, "body">) =>
-  fetchFailedSelector<{}, DelayedJobsFindPathParams>({
-    url: "/jobs/v3/delayedJobs/{uuid}",
-    method: "get",
-    ...variables
-  });
+  fetchFailedSelector<{}, DelayedJobsFindPathParams>({ url: DELAYED_JOBS_FIND_URL, method: "get", ...variables });
 
-export const bulkUpdateJobsIsFetching = isFetchingSelector<{}, {}>({
-  url: "/jobs/v3/delayedJobs/bulk-update",
-  method: "patch"
-});
+export const BULK_UPDATE_JOBS_URL = "/jobs/v3/delayedJobs/bulk-update";
 
-export const bulkUpdateJobsFetchFailed = fetchFailedSelector<{}, {}>({
-  url: "/jobs/v3/delayedJobs/bulk-update",
-  method: "patch"
-});
+export const bulkUpdateJobsIsFetching = isFetchingSelector<{}, {}>({ url: BULK_UPDATE_JOBS_URL, method: "patch" });
+
+export const bulkUpdateJobsFetchFailed = fetchFailedSelector<{}, {}>({ url: BULK_UPDATE_JOBS_URL, method: "patch" });

--- a/src/generated/v3/researchService/researchServiceSelectors.ts
+++ b/src/generated/v3/researchService/researchServiceSelectors.ts
@@ -7,37 +7,35 @@ import {
   BoundingBoxGetVariables
 } from "./researchServiceComponents";
 
+export const SITE_POLYGONS_INDEX_URL = "/research/v3/sitePolygons";
+
 export const sitePolygonsIndexIsFetching = (variables: Omit<SitePolygonsIndexVariables, "body">) =>
-  isFetchingSelector<SitePolygonsIndexQueryParams, {}>({
-    url: "/research/v3/sitePolygons",
-    method: "get",
-    ...variables
-  });
+  isFetchingSelector<SitePolygonsIndexQueryParams, {}>({ url: SITE_POLYGONS_INDEX_URL, method: "get", ...variables });
 
 export const sitePolygonsIndexFetchFailed = (variables: Omit<SitePolygonsIndexVariables, "body">) =>
-  fetchFailedSelector<SitePolygonsIndexQueryParams, {}>({
-    url: "/research/v3/sitePolygons",
-    method: "get",
-    ...variables
-  });
+  fetchFailedSelector<SitePolygonsIndexQueryParams, {}>({ url: SITE_POLYGONS_INDEX_URL, method: "get", ...variables });
 
 export const sitePolygonsIndexIndexMeta = (
   resource: ResourceType,
   variables: Omit<SitePolygonsIndexVariables, "body">
-) => indexMetaSelector<SitePolygonsIndexQueryParams, {}>({ url: "/research/v3/sitePolygons", resource, ...variables });
+) => indexMetaSelector<SitePolygonsIndexQueryParams, {}>({ url: SITE_POLYGONS_INDEX_URL, resource, ...variables });
+
+export const BULK_UPDATE_SITE_POLYGONS_URL = "/research/v3/sitePolygons";
 
 export const bulkUpdateSitePolygonsIsFetching = isFetchingSelector<{}, {}>({
-  url: "/research/v3/sitePolygons",
+  url: BULK_UPDATE_SITE_POLYGONS_URL,
   method: "patch"
 });
 
 export const bulkUpdateSitePolygonsFetchFailed = fetchFailedSelector<{}, {}>({
-  url: "/research/v3/sitePolygons",
+  url: BULK_UPDATE_SITE_POLYGONS_URL,
   method: "patch"
 });
 
+export const BOUNDING_BOX_GET_URL = "/boundingBoxes/v3/get";
+
 export const boundingBoxGetIsFetching = (variables: Omit<BoundingBoxGetVariables, "body">) =>
-  isFetchingSelector<BoundingBoxGetQueryParams, {}>({ url: "/boundingBoxes/v3/get", method: "get", ...variables });
+  isFetchingSelector<BoundingBoxGetQueryParams, {}>({ url: BOUNDING_BOX_GET_URL, method: "get", ...variables });
 
 export const boundingBoxGetFetchFailed = (variables: Omit<BoundingBoxGetVariables, "body">) =>
-  fetchFailedSelector<BoundingBoxGetQueryParams, {}>({ url: "/boundingBoxes/v3/get", method: "get", ...variables });
+  fetchFailedSelector<BoundingBoxGetQueryParams, {}>({ url: BOUNDING_BOX_GET_URL, method: "get", ...variables });

--- a/src/generated/v3/userService/userServiceSelectors.ts
+++ b/src/generated/v3/userService/userServiceSelectors.ts
@@ -8,50 +8,56 @@ import {
   ResetPasswordVariables
 } from "./userServiceComponents";
 
-export const authLoginIsFetching = isFetchingSelector<{}, {}>({ url: "/auth/v3/logins", method: "post" });
+export const AUTH_LOGIN_URL = "/auth/v3/logins";
 
-export const authLoginFetchFailed = fetchFailedSelector<{}, {}>({ url: "/auth/v3/logins", method: "post" });
+export const authLoginIsFetching = isFetchingSelector<{}, {}>({ url: AUTH_LOGIN_URL, method: "post" });
+
+export const authLoginFetchFailed = fetchFailedSelector<{}, {}>({ url: AUTH_LOGIN_URL, method: "post" });
+
+export const USERS_FIND_URL = "/users/v3/users/{uuid}";
 
 export const usersFindIsFetching = (variables: Omit<UsersFindVariables, "body">) =>
-  isFetchingSelector<{}, UsersFindPathParams>({ url: "/users/v3/users/{uuid}", method: "get", ...variables });
+  isFetchingSelector<{}, UsersFindPathParams>({ url: USERS_FIND_URL, method: "get", ...variables });
 
 export const usersFindFetchFailed = (variables: Omit<UsersFindVariables, "body">) =>
-  fetchFailedSelector<{}, UsersFindPathParams>({ url: "/users/v3/users/{uuid}", method: "get", ...variables });
+  fetchFailedSelector<{}, UsersFindPathParams>({ url: USERS_FIND_URL, method: "get", ...variables });
+
+export const USER_UPDATE_URL = "/users/v3/users/{uuid}";
 
 export const userUpdateIsFetching = (variables: Omit<UserUpdateVariables, "body">) =>
-  isFetchingSelector<{}, UserUpdatePathParams>({ url: "/users/v3/users/{uuid}", method: "patch", ...variables });
+  isFetchingSelector<{}, UserUpdatePathParams>({ url: USER_UPDATE_URL, method: "patch", ...variables });
 
 export const userUpdateFetchFailed = (variables: Omit<UserUpdateVariables, "body">) =>
-  fetchFailedSelector<{}, UserUpdatePathParams>({ url: "/users/v3/users/{uuid}", method: "patch", ...variables });
+  fetchFailedSelector<{}, UserUpdatePathParams>({ url: USER_UPDATE_URL, method: "patch", ...variables });
 
-export const userCreationIsFetching = isFetchingSelector<{}, {}>({ url: "/users/v3/users", method: "post" });
+export const USER_CREATION_URL = "/users/v3/users";
 
-export const userCreationFetchFailed = fetchFailedSelector<{}, {}>({ url: "/users/v3/users", method: "post" });
+export const userCreationIsFetching = isFetchingSelector<{}, {}>({ url: USER_CREATION_URL, method: "post" });
+
+export const userCreationFetchFailed = fetchFailedSelector<{}, {}>({ url: USER_CREATION_URL, method: "post" });
+
+export const REQUEST_PASSWORD_RESET_URL = "/auth/v3/passwordResets";
 
 export const requestPasswordResetIsFetching = isFetchingSelector<{}, {}>({
-  url: "/auth/v3/passwordResets",
+  url: REQUEST_PASSWORD_RESET_URL,
   method: "post"
 });
 
 export const requestPasswordResetFetchFailed = fetchFailedSelector<{}, {}>({
-  url: "/auth/v3/passwordResets",
+  url: REQUEST_PASSWORD_RESET_URL,
   method: "post"
 });
 
+export const RESET_PASSWORD_URL = "/auth/v3/passwordResets/{token}";
+
 export const resetPasswordIsFetching = (variables: Omit<ResetPasswordVariables, "body">) =>
-  isFetchingSelector<{}, ResetPasswordPathParams>({
-    url: "/auth/v3/passwordResets/{token}",
-    method: "put",
-    ...variables
-  });
+  isFetchingSelector<{}, ResetPasswordPathParams>({ url: RESET_PASSWORD_URL, method: "put", ...variables });
 
 export const resetPasswordFetchFailed = (variables: Omit<ResetPasswordVariables, "body">) =>
-  fetchFailedSelector<{}, ResetPasswordPathParams>({
-    url: "/auth/v3/passwordResets/{token}",
-    method: "put",
-    ...variables
-  });
+  fetchFailedSelector<{}, ResetPasswordPathParams>({ url: RESET_PASSWORD_URL, method: "put", ...variables });
 
-export const verifyUserIsFetching = isFetchingSelector<{}, {}>({ url: "/auth/v3/verifications", method: "post" });
+export const VERIFY_USER_URL = "/auth/v3/verifications";
 
-export const verifyUserFetchFailed = fetchFailedSelector<{}, {}>({ url: "/auth/v3/verifications", method: "post" });
+export const verifyUserIsFetching = isFetchingSelector<{}, {}>({ url: VERIFY_USER_URL, method: "post" });
+
+export const verifyUserFetchFailed = fetchFailedSelector<{}, {}>({ url: VERIFY_USER_URL, method: "post" });


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-2211

To enable this possibility, I added a system that I overlooked in the initial implementation: the ability to clear out a failed API response so that the same endpoint can be called again. 