### PR TITLE
[TM-2265] Solve a race condition for form submissions.

### DIFF
--- a/src/admin/components/Dialogs/StatusChangeModal.tsx
+++ b/src/admin/components/Dialogs/StatusChangeModal.tsx
@@ -19,14 +19,11 @@ import modules from "@/admin/modules";
 import { validateForm } from "@/admin/utils/forms";
 import { SupportedEntity, useFullEntity } from "@/connections/Entity";
 import { useNotificationContext } from "@/context/notification.provider";
-import {
-  GetV2FormsENTITYUUIDResponse,
-  useGetV2FormsENTITYUUID,
-  usePostV2AdminENTITYUUIDReminder
-} from "@/generated/apiComponents";
+import { usePostV2AdminENTITYUUIDReminder } from "@/generated/apiComponents";
 import { SiteUpdateAttributes } from "@/generated/v3/entityService/entityServiceSchemas";
 import { singularEntityNameToPlural } from "@/helpers/entity";
 import { useUpdateComplete } from "@/hooks/useConnectionUpdate";
+import { useEntityForm } from "@/hooks/useFormGet";
 import { SingularEntityName } from "@/types/common";
 import { optionToChoices } from "@/utils/options";
 
@@ -100,17 +97,7 @@ const StatusChangeModal = ({ handleClose, status, ...dialogProps }: StatusChange
     }
   })();
 
-  const { data: formResponse } = useGetV2FormsENTITYUUID<{ data: GetV2FormsENTITYUUIDResponse }>(
-    {
-      pathParams: {
-        entity: resourceName,
-        uuid: record.id
-      }
-    },
-    {
-      enabled: !!record?.id
-    }
-  );
+  const { formData: formResponse } = useEntityForm(resourceName, record.id);
 
   const questions = formResponse?.data.form?.form_sections.flatMap((section: { form_questions: { label: string }[] }) =>
     section.form_questions.map((question: any) => ({

--- a/src/admin/components/EntityEdit/EntityEdit.tsx
+++ b/src/admin/components/EntityEdit/EntityEdit.tsx
@@ -9,9 +9,10 @@ import WizardForm from "@/components/extensive/WizardForm";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
 import EntityProvider from "@/context/entity.provider";
 import FrameworkProvider, { Framework } from "@/context/framework.provider";
-import { GetV2FormsENTITYUUIDResponse, useGetV2ENTITYUUID, useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
+import { GetV2FormsENTITYUUIDResponse, useGetV2ENTITYUUID } from "@/generated/apiComponents";
 import { normalizedFormData } from "@/helpers/customForms";
 import { pluralEntityNameToSingular } from "@/helpers/entity";
+import { useEntityForm } from "@/hooks/useFormGet";
 import { useFormUpdate } from "@/hooks/useFormUpdate";
 import {
   useGetCustomFormSteps,
@@ -42,11 +43,7 @@ export const EntityEdit = () => {
 
   const { updateEntity, error, isSuccess, isUpdating } = useFormUpdate(entityName, entityUUID);
 
-  const {
-    data: formResponse,
-    isLoading,
-    isError: loadError
-  } = useGetV2FormsENTITYUUID({ pathParams: { entity: entityName, uuid: entityUUID } });
+  const { formData: formResponse, isLoading, loadError } = useEntityForm(entityName, entityUUID);
 
   const { data: entityValue } = useGetV2ENTITYUUID({ pathParams: { entity: entityName, uuid: entityUUID } });
 

--- a/src/admin/components/ResourceTabs/ChangeRequestsTab/ChangeRequestsTab.tsx
+++ b/src/admin/components/ResourceTabs/ChangeRequestsTab/ChangeRequestsTab.tsx
@@ -18,8 +18,8 @@ import ChangeRow from "@/admin/components/ResourceTabs/ChangeRequestsTab/ChangeR
 import useFormChanges from "@/admin/components/ResourceTabs/ChangeRequestsTab/useFormChanges";
 import List from "@/components/extensive/List/List";
 import { Framework } from "@/context/framework.provider";
-import { useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
 import { getCustomFormSteps } from "@/helpers/customForms";
+import { useEntityForm } from "@/hooks/useFormGet";
 import { Entity, EntityName, SingularEntityName } from "@/types/common";
 
 import ChangeRequestRequestMoreInfoModal, { IStatus } from "./MoreInformationModal";
@@ -35,15 +35,7 @@ const ChangeRequestsTab: FC<IProps> = ({ label, entity, singularEntity, ...rest 
   const t = useT();
   const [statusToChangeTo, setStatusToChangeTo] = useState<IStatus>();
 
-  // Current values
-  const { data: currentValues, refetch } = useGetV2FormsENTITYUUID(
-    {
-      pathParams: { entity: entity, uuid: ctx?.record?.uuid }
-    },
-    {
-      enabled: !!ctx?.record?.uuid
-    }
-  );
+  const { formData: currentValues, refetch } = useEntityForm(entity, ctx?.record?.uuid);
 
   // @ts-ignore
   const changeRequest = currentValues?.data?.update_request;
@@ -190,7 +182,7 @@ const ChangeRequestsTab: FC<IProps> = ({ label, entity, singularEntity, ...rest 
           uuid={changeRequest?.uuid}
           handleClose={() => {
             setStatusToChangeTo(undefined);
-            refetch();
+            refetch?.();
           }}
           form={form}
         />

--- a/src/admin/components/ResourceTabs/HistoryTab/HistoryTab.tsx
+++ b/src/admin/components/ResourceTabs/HistoryTab/HistoryTab.tsx
@@ -6,8 +6,8 @@ import { setDefaultConditionalFieldsAnswers } from "@/admin/utils/forms";
 import Accordion from "@/components/elements/Accordion/Accordion";
 import { FieldType } from "@/components/extensive/WizardForm/types";
 import { useFrameworkContext } from "@/context/framework.provider";
-import { GetV2FormsENTITYUUIDResponse, useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
 import { getCustomFormSteps, normalizedFormDefaultValue } from "@/helpers/customForms";
+import { useEntityForm } from "@/hooks/useFormGet";
 import { EntityName } from "@/types/common";
 import { formatDescriptionData, formatDocumentData } from "@/utils/financialReport";
 
@@ -28,13 +28,7 @@ const HistoryTab: FC<IProps> = ({ label, entity, ...rest }) => {
   const entityName = entity ?? record?.entity;
   const entityUuid = record?.uuid;
 
-  const { data: response, isLoading: queryLoading } = useGetV2FormsENTITYUUID<{ data: GetV2FormsENTITYUUIDResponse }>({
-    pathParams: {
-      uuid: entityUuid as string,
-      entity: entityName as string
-    }
-  });
-
+  const { formData: response, isLoading: queryLoading } = useEntityForm(entityName, entityUuid);
   const isLoading = ctxLoading || queryLoading;
 
   if (isLoading || !record) return null;

--- a/src/admin/components/ResourceTabs/InformationTab/index.tsx
+++ b/src/admin/components/ResourceTabs/InformationTab/index.tsx
@@ -16,9 +16,9 @@ import { usePlantTotalCount } from "@/components/extensive/Tables/TreeSpeciesTab
 import { SupportedEntity } from "@/connections/EntityAssociation";
 import { ContextCondition } from "@/context/ContextCondition";
 import { Framework, useFrameworkContext } from "@/context/framework.provider";
-import { GetV2FormsENTITYUUIDResponse, useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
 import { getCustomFormSteps, normalizedFormDefaultValue } from "@/helpers/customForms";
 import { pluralEntityNameToSingular } from "@/helpers/entity";
+import { useEntityForm } from "@/hooks/useFormGet";
 import { EntityName } from "@/types/common";
 
 import InformationTabRow from "./components/InformationTabRow";
@@ -61,13 +61,7 @@ const InformationTab: FC<IProps> = props => {
   const totalCountTreePlanted = usePlantTotalCount({ entity, entityUuid, collection: "tree-planted" });
   const totalCountReplanting = usePlantTotalCount({ entity, entityUuid, collection: "replanting" });
 
-  const { data: response, isLoading: queryLoading } = useGetV2FormsENTITYUUID<{ data: GetV2FormsENTITYUUIDResponse }>({
-    pathParams: {
-      uuid: record?.uuid,
-      entity: props.type
-    }
-  });
-
+  const { formData: response, isLoading: queryLoading } = useEntityForm(props.type, record?.uuid);
   const isLoading = ctxLoading || queryLoading;
 
   if (isLoading || !record) return null;

--- a/src/components/generic/Loading/LoadingContainer.tsx
+++ b/src/components/generic/Loading/LoadingContainer.tsx
@@ -1,5 +1,4 @@
-import { Fragment, PropsWithChildren } from "react";
-import { Else, If, Then } from "react-if";
+import { FC, PropsWithChildren } from "react";
 
 import Paper from "@/components/elements/Paper/Paper";
 
@@ -11,23 +10,22 @@ interface LoadingContainerProps {
   wrapInPaper?: boolean;
 }
 
-const LoadingContainer = ({ className, wrapInPaper, loading, children }: PropsWithChildren<LoadingContainerProps>) => {
-  return (
-    <Fragment>
-      <If condition={loading}>
-        <Then>
-          {wrapInPaper ? (
-            <Paper>
-              <Loader className={className} />
-            </Paper>
-          ) : (
-            <Loader className={className} />
-          )}
-        </Then>
-        <Else>{children}</Else>
-      </If>
-    </Fragment>
+const LoadingContainer: FC<PropsWithChildren<LoadingContainerProps>> = ({
+  className,
+  wrapInPaper,
+  loading,
+  children
+}) =>
+  loading ? (
+    wrapInPaper ? (
+      <Paper>
+        <Loader className={className} />
+      </Paper>
+    ) : (
+      <Loader className={className} />
+    )
+  ) : (
+    <>{children}</>
   );
-};
 
 export default LoadingContainer;

--- a/src/hooks/useFormGet.ts
+++ b/src/hooks/useFormGet.ts
@@ -1,0 +1,55 @@
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+import {
+  GetV2FormsENTITYUUIDResponse,
+  useGetV2FormsENTITYUUID,
+  useGetV2FormsSubmissionsUUID
+} from "@/generated/apiComponents";
+import { FormSubmissionRead } from "@/generated/apiSchemas";
+
+/**
+ * Protects the FE from first rendering with an out of date cached copy of the form data by only
+ * returning the form data once `onSettled` has been called on the request.
+ */
+export const useFormSubmission = (uuid?: string) => {
+  const [formDataValid, setFormDataValid] = useState(false);
+  const router = useRouter();
+  const { data: formData } = useGetV2FormsSubmissionsUUID<{ data: FormSubmissionRead }>(
+    { pathParams: { uuid: uuid ?? "" }, queryParams: { lang: router.locale } },
+    {
+      enabled: uuid != null,
+      onSettled: () => setFormDataValid(true)
+    }
+  );
+
+  return { isLoading: !formDataValid, formData: formDataValid ? formData : undefined };
+};
+
+/**
+ * Protects the FE from first rendering with an out of date cached copy of the form data by only
+ * returning the form data once `onSettled` has been called on the request.
+ */
+export const useEntityForm = (entity?: string, uuid?: string) => {
+  const [formDataValid, setFormDataValid] = useState(false);
+  const router = useRouter();
+  const {
+    data: formData,
+    isError: loadError,
+    refetch
+  } = useGetV2FormsENTITYUUID<{ data: GetV2FormsENTITYUUIDResponse }>(
+    {
+      pathParams: {
+        entity: entity ?? "",
+        uuid: uuid ?? ""
+      },
+      queryParams: { lang: router.locale }
+    },
+    {
+      enabled: entity != null && uuid != null,
+      onSettled: () => setFormDataValid(true)
+    }
+  );
+
+  return formDataValid ? { isLoading: false, formData, loadError, refetch } : { isLoading: true };
+};

--- a/src/hooks/useProcessRecordData.ts
+++ b/src/hooks/useProcessRecordData.ts
@@ -1,14 +1,9 @@
 import { useMemo } from "react";
 
-import { GetV2FormsENTITYUUIDResponse, useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
+import { useEntityForm } from "@/hooks/useFormGet";
 
 export function useProcessRecordData(modelUUID: string, modelName: string, inputType: string) {
-  const { data: record } = useGetV2FormsENTITYUUID<{ data: GetV2FormsENTITYUUIDResponse }>({
-    pathParams: {
-      uuid: modelUUID,
-      entity: modelName
-    }
-  });
+  const { formData: record } = useEntityForm(modelName, modelUUID);
 
   return useMemo(() => {
     if (record?.data?.form == null) return false;

--- a/src/pages/entity/[entityName]/create/[frameworkKey].page.tsx
+++ b/src/pages/entity/[entityName]/create/[frameworkKey].page.tsx
@@ -7,8 +7,9 @@ import WizardFormIntro from "@/components/extensive/WizardForm/WizardFormIntro";
 import BackgroundLayout from "@/components/generic/Layout/BackgroundLayout";
 import ContentLayout from "@/components/generic/Layout/ContentLayout";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
-import { useGetV2FormsENTITYUUID, useGetV2FormsUUID, usePostV2FormsENTITY } from "@/generated/apiComponents";
+import { useGetV2FormsUUID, usePostV2FormsENTITY } from "@/generated/apiComponents";
 import { FormRead } from "@/generated/apiSchemas";
+import { useEntityForm } from "@/hooks/useFormGet";
 import { useGetReportingFrameworkFormKey } from "@/hooks/useGetFormKey";
 import { EntityName } from "@/types/common";
 
@@ -45,13 +46,7 @@ const EntityIntroPage = () => {
     }
   );
 
-  const { data: entityData } = useGetV2FormsENTITYUUID(
-    {
-      pathParams: { entity: entityName, uuid: entityUUID! },
-      queryParams: { lang: router.locale }
-    },
-    { enabled: !!entityUUID }
-  );
+  const { formData: entityData } = useEntityForm(entityName, entityUUID);
 
   //@ts-ignore
   const form = entityData?.data?.form || formData?.data;

--- a/src/pages/entity/[entityName]/edit/[uuid]/confirm.page.tsx
+++ b/src/pages/entity/[entityName]/edit/[uuid]/confirm.page.tsx
@@ -8,8 +8,9 @@ import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import BackgroundLayout from "@/components/generic/Layout/BackgroundLayout";
 import ContentLayout from "@/components/generic/Layout/ContentLayout";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
-import { GetV2FormsENTITYUUIDResponse, useGetV2ENTITYUUID, useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
+import { GetV2FormsENTITYUUIDResponse, useGetV2ENTITYUUID } from "@/generated/apiComponents";
 import { getEntityDetailPageLink } from "@/helpers/entity";
+import { useEntityForm } from "@/hooks/useFormGet";
 import { EntityName } from "@/types/common";
 
 /* Todo: To select actions and their copies based on form's parent(application, project, site, etc) in 2.4 */
@@ -19,12 +20,7 @@ const ConfirmPage = () => {
   const entityName = router.query.entityName as EntityName;
   const entityUUID = router.query.uuid as string;
 
-  const { data, isLoading } = useGetV2FormsENTITYUUID({
-    pathParams: { entity: entityName, uuid: entityUUID },
-    queryParams: {
-      lang: router.locale
-    }
-  });
+  const { formData: data, isLoading } = useEntityForm(entityName, entityUUID);
 
   const { data: entityData } = useGetV2ENTITYUUID({
     pathParams: { entity: entityName, uuid: entityUUID }

--- a/src/pages/entity/[entityName]/edit/[uuid]/index.page.tsx
+++ b/src/pages/entity/[entityName]/edit/[uuid]/index.page.tsx
@@ -5,7 +5,8 @@ import PageFooter from "@/components/extensive/PageElements/Footer/PageFooter";
 import BackgroundLayout from "@/components/generic/Layout/BackgroundLayout";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
 import FrameworkProvider from "@/context/framework.provider";
-import { GetV2FormsENTITYUUIDResponse, useGetV2ENTITYUUID, useGetV2FormsENTITYUUID } from "@/generated/apiComponents";
+import { GetV2FormsENTITYUUIDResponse, useGetV2ENTITYUUID } from "@/generated/apiComponents";
+import { useEntityForm } from "@/hooks/useFormGet";
 import EditEntityForm from "@/pages/entity/[entityName]/edit/[uuid]/EditEntityForm";
 import { EntityName } from "@/types/common";
 
@@ -23,14 +24,11 @@ const EditEntityPage = () => {
   });
   const entity = entityData?.data ?? {}; //Do not abuse this since forms should stay entity agnostic!
 
-  const { data, isLoading, isError } = useGetV2FormsENTITYUUID({
-    pathParams: { entity: entityName, uuid: entityUUID },
-    queryParams: { lang: router.locale }
-  });
+  const { formData: data, isLoading, loadError } = useEntityForm(entityName, entityUUID);
   //@ts-ignore
   const formData = (data?.data ?? {}) as GetV2FormsENTITYUUIDResponse;
 
-  if (isError) {
+  if (loadError) {
     return notFound();
   }
 

--- a/src/pages/form/submission/[submissionUUID]/confirm.page.tsx
+++ b/src/pages/form/submission/[submissionUUID]/confirm.page.tsx
@@ -8,8 +8,7 @@ import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import BackgroundLayout from "@/components/generic/Layout/BackgroundLayout";
 import ContentLayout from "@/components/generic/Layout/ContentLayout";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
-import { useGetV2FormsSubmissionsUUID } from "@/generated/apiComponents";
-import { FormSubmissionRead } from "@/generated/apiSchemas";
+import { useFormSubmission } from "@/hooks/useFormGet";
 
 /* Todo: To select actions and their copies based on form's parent(application, project, site, etc) in 2.4 */
 const ConfirmPage = () => {
@@ -17,12 +16,7 @@ const ConfirmPage = () => {
   const router = useRouter();
   const submissionUUID = router.query.submissionUUID as string;
 
-  const { data: formData, isLoading } = useGetV2FormsSubmissionsUUID<{ data: FormSubmissionRead }>(
-    { pathParams: { uuid: submissionUUID }, queryParams: { lang: router.locale } },
-    {
-      enabled: !!submissionUUID
-    }
-  );
+  const { formData, isLoading } = useFormSubmission(submissionUUID);
 
   return (
     <BackgroundLayout>

--- a/src/pages/form/submission/[submissionUUID]/index.page.tsx
+++ b/src/pages/form/submission/[submissionUUID]/index.page.tsx
@@ -5,13 +5,9 @@ import WizardForm from "@/components/extensive/WizardForm";
 import BackgroundLayout from "@/components/generic/Layout/BackgroundLayout";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
 import FrameworkProvider, { useFramework } from "@/context/framework.provider";
-import {
-  useGetV2FormsSubmissionsUUID,
-  usePatchV2FormsSubmissionsUUID,
-  usePutV2FormsSubmissionsSubmitUUID
-} from "@/generated/apiComponents";
-import { FormSubmissionRead } from "@/generated/apiSchemas";
+import { usePatchV2FormsSubmissionsUUID, usePutV2FormsSubmissionsSubmitUUID } from "@/generated/apiComponents";
 import { normalizedFormData } from "@/helpers/customForms";
+import { useFormSubmission } from "@/hooks/useFormGet";
 import {
   useGetCustomFormSteps,
   useNormalizedFormDefaultValue
@@ -22,12 +18,7 @@ const SubmissionPage = () => {
   const router = useRouter();
   const submissionUUID = router.query.submissionUUID as string;
 
-  const { data: formData, isLoading } = useGetV2FormsSubmissionsUUID<{ data: FormSubmissionRead }>(
-    { pathParams: { uuid: submissionUUID }, queryParams: { lang: router.locale } },
-    {
-      enabled: !!submissionUUID
-    }
-  );
+  const { isLoading, formData } = useFormSubmission(submissionUUID);
 
   const { mutate: updateSubmission, isSuccess, isLoading: isUpdating, error } = usePatchV2FormsSubmissionsUUID({});
 

--- a/src/pages/form/submission/[submissionUUID]/intro.page.tsx
+++ b/src/pages/form/submission/[submissionUUID]/intro.page.tsx
@@ -6,22 +6,14 @@ import WizardFormIntro from "@/components/extensive/WizardForm/WizardFormIntro";
 import BackgroundLayout from "@/components/generic/Layout/BackgroundLayout";
 import ContentLayout from "@/components/generic/Layout/ContentLayout";
 import LoadingContainer from "@/components/generic/Loading/LoadingContainer";
-import { useGetV2FormsSubmissionsUUID } from "@/generated/apiComponents";
-import { FormSubmissionRead } from "@/generated/apiSchemas";
+import { useFormSubmission } from "@/hooks/useFormGet";
 
-//Todo: To fetch form data and populate title, image, description and downloadLink when endpoint is ready
 const FormIntroPage = () => {
   const t = useT();
   const router = useRouter();
   const submissionUUID = router.query.submissionUUID as string;
 
-  const { data: submissionData } = useGetV2FormsSubmissionsUUID<{ data: FormSubmissionRead }>(
-    { pathParams: { uuid: submissionUUID }, queryParams: { lang: router.locale } },
-    {
-      enabled: !!submissionUUID,
-      staleTime: 300_000
-    }
-  );
+  const { formData: submissionData } = useFormSubmission(submissionUUID);
 
   const formData = submissionData?.data.form;
 


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-2265

This was a fun one to track down: The v2 react query integration will immediately render with cached data while it goes to the server to fetch the latest when mounting a component with a given request. Normally that's fine, and while I don't love that it still goes to the server if it thinks it has up to date data, it's an approach I understand and would normally be fine. 

However, in the case of forms, if the server was taking too long to respond, then the wizard form would render with the cached data. Again, that would normally be fine. However, in the case of the v2 form system, when an update is sent to the server, the react query layer had no way of knowing that its cache of the GET data should be either removed or updated with the server response. This is a whole class of bug that the v3 layer solves. 

In this case, the bug was manifesting as: 
1. User opens an application and changes some stuff
2. User clicks "close and continue later" or just navigates to a different part of the site
3. User navigates back to the application. At this point the cache of GET data from the initial fetch of (1) was out of date
4. Because applications take a long time to load from the server, the wizard form starts rendering immediately with the stale data
5. If the user does _anything_ that causes a save of the form data to the server (navigate to a different form step, change any data, unfocus the window, etc), the client would send its out of date data to the server and over write the previous update

Very weird behavior that I'm glad I was able to figure out. Can't wait to get this system moved to v3!