### PR TITLE
[TM-2896] Replace fetchBlob with a better general purpose downloadFile function

### DIFF
--- a/src/admin/components/Dialogs/FrameworkSelectionDialog.tsx
+++ b/src/admin/components/Dialogs/FrameworkSelectionDialog.tsx
@@ -1,14 +1,12 @@
 import { CheckCircle, InfoOutlined } from "@mui/icons-material";
 import { Button, Dialog, DialogActions, DialogContent, DialogProps, DialogTitle } from "@mui/material";
-import { capitalize, split } from "lodash";
 import { FC, useCallback, useState } from "react";
 import { AutocompleteInput, Form } from "react-admin";
 import { FieldValues } from "react-hook-form";
 import * as yup from "yup";
 
-import { useGetUserRole } from "@/admin/hooks/useGetUserRole";
 import { validateForm } from "@/admin/utils/forms";
-import { downloadEntityAllCsv, SupportedEntity } from "@/connections/Entity";
+import { SupportedEntity } from "@/connections/Entity";
 import { useUserFrameworkChoices } from "@/constants/options/userFrameworksChoices";
 import { toFramework } from "@/context/framework.provider";
 import { ToastType, useToastContext } from "@/context/toast.provider";
@@ -16,7 +14,6 @@ import { entityExportAll, EntityExportAllQueryParams } from "@/generated/v3/enti
 import { v3EntityName } from "@/helpers/entity";
 import { EntityName } from "@/types/common";
 import Log from "@/utils/log";
-import { downloadFileBlob, downloadFileUrl } from "@/utils/network";
 
 interface FrameworkSelectionDialogContentProps {
   onCancel: () => void;
@@ -61,50 +58,23 @@ export function useFrameworkExport(entity: EntityName, choices: any[]) {
 
   const { openToast } = useToastContext();
 
-  const { isSuperAdmin, isFrameworkAdmin } = useGetUserRole();
-
   const onExport = useCallback(
     async (framework: string) => {
       setExporting(true);
 
-      const reportError = (error?: any) => {
-        Log.error("Export failed", error);
-        openToast("Something went wrong!", ToastType.ERROR);
-      };
-
       try {
         const entityName = v3EntityName(entity) as SupportedEntity;
-        const frameworkKey = toFramework(framework);
-        const cachedReportDownload = (isSuperAdmin || isFrameworkAdmin) && entityName !== "financialReports";
-        if (cachedReportDownload) {
-          const { data, loadFailure } = await downloadEntityAllCsv(entityName, frameworkKey);
-          if (loadFailure != null) {
-            reportError(loadFailure);
-          } else {
-            downloadFileUrl(data?.url as string);
-          }
-        } else {
-          try {
-            const { fileName, blob } = await entityExportAll.fetchBlob({
-              pathParams: { entity: entityName },
-              queryParams: { frameworkKey: frameworkKey as EntityExportAllQueryParams["frameworkKey"] }
-            });
-            await downloadFileBlob(
-              blob,
-              fileName ?? `${split(entity, "-").map(capitalize).join(" ")} - ${framework}.csv`
-            );
-          } catch {
-            reportError();
-          }
-        }
+        const frameworkKey = toFramework(framework) as EntityExportAllQueryParams["frameworkKey"];
+        await entityExportAll.downloadFile({ pathParams: { entity: entityName }, queryParams: { frameworkKey } });
       } catch (error) {
-        reportError(error);
+        Log.error("Export failed", error);
+        openToast("Something went wrong!", ToastType.ERROR);
       } finally {
         setExporting(false);
         setModalOpen(false);
       }
     },
-    [entity, isSuperAdmin, isFrameworkAdmin, openToast]
+    [entity, openToast]
   );
 
   return {

--- a/src/admin/components/ResourceTabs/InformationTab/components/ProjectInformationAside/QuickActions.tsx
+++ b/src/admin/components/ResourceTabs/InformationTab/components/ProjectInformationAside/QuickActions.tsx
@@ -13,7 +13,6 @@ import { Framework } from "@/context/framework.provider";
 import { entityExportAll } from "@/generated/v3/entityService/entityServiceComponents";
 import { v3EntityName } from "@/helpers/entity";
 import Log from "@/utils/log";
-import { downloadFileBlob } from "@/utils/network";
 
 const QuickActions: FC = () => {
   const { record } = useShowContext();
@@ -34,11 +33,10 @@ const QuickActions: FC = () => {
       }
     } else {
       try {
-        const { blob } = await entityExportAll.fetchBlob({
+        await entityExportAll.downloadFile({
           pathParams: { entity: v3EntityName(entity) as SupportedEntity },
           queryParams: { projectUuid: record.uuid }
         });
-        await downloadFileBlob(blob, `${record.name} ${entity.replace("-reports", "")} reports.csv`);
       } catch (error) {
         Log.error("Failed to download entity CSV:", error);
       }

--- a/src/admin/components/ResourceTabs/MonitoredTab/components/DataCard.tsx
+++ b/src/admin/components/ResourceTabs/MonitoredTab/components/DataCard.tsx
@@ -45,7 +45,6 @@ import {
   getOrderTop3,
   replaceTextWithParams
 } from "@/utils/MonitoredIndicatorUtils";
-import { downloadFileBlob } from "@/utils/network";
 
 import { useMonitoredData } from "../hooks/useMonitoredData";
 import MonitoredCharts from "./MonitoredCharts";
@@ -764,14 +763,16 @@ const DataCard = ({
   const handleExport = async () => {
     try {
       setExporting(true);
-      const { blob } = await exportIndicatorCsv.fetchBlob({
-        pathParams: {
-          entityType: type,
-          entityUuid: record.uuid,
-          slug: indicatorSlug as ExportIndicatorCsvPathParams["slug"]
-        }
-      });
-      downloadFileBlob(blob, `Indicator (${DROPDOWN_OPTIONS.find(item => item.slug === indicatorSlug)?.title}).csv`);
+      await exportIndicatorCsv.downloadFile(
+        {
+          pathParams: {
+            entityType: type,
+            entityUuid: record.uuid,
+            slug: indicatorSlug as ExportIndicatorCsvPathParams["slug"]
+          }
+        },
+        `Indicator (${DROPDOWN_OPTIONS.find(item => item.slug === indicatorSlug)?.title}).csv`
+      );
 
       openNotification("success", t("Success! Export completed."), t("The export has been completed successfully."));
       setExporting(false);

--- a/src/admin/modules/application/context/export.provider.tsx
+++ b/src/admin/modules/application/context/export.provider.tsx
@@ -1,11 +1,11 @@
-import { isString } from "lodash";
 import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from "react";
 import { useNotify } from "react-admin";
 
 import ExportProcessingAlert from "@/admin/components/Alerts/ExportProcessingAlert";
-import { downloadApplicationExport } from "@/connections/FundingProgramme";
-import { formSubmissionsExportCsv } from "@/generated/v3/entityService/entityServiceComponents";
-import { downloadFileBlob, downloadFileUrl } from "@/utils/network";
+import {
+  formSubmissionsExportCsv,
+  fundingProgrammeExportAll
+} from "@/generated/v3/entityService/entityServiceComponents";
 
 type ExportType = {
   loading: boolean;
@@ -30,36 +30,18 @@ const ExportProvider = ({ children }: ExportProviderProps) => {
 
   const exportApplications = useCallback(
     async ({ fundingProgrammeUuid, formUuid }: { fundingProgrammeUuid?: string; formUuid?: string }) => {
-      const exporter = async (fn: () => Promise<{ fileName?: string; response: Blob | string }>) => {
-        try {
-          setLoading(true);
-          const { fileName, response } = await fn();
-          if (isString(response)) {
-            downloadFileUrl(response, fileName);
-          } else {
-            await downloadFileBlob(response, fileName ?? "Applications.csv");
-          }
-          setLoading(false);
-        } catch (err: any) {
-          setLoading(false);
-          setError(err.message);
-          notify(err.message ?? "Export Error", { undoable: false, type: "error" });
+      try {
+        setLoading(true);
+        if (formUuid != null) {
+          await formSubmissionsExportCsv.downloadFile({ pathParams: { uuid: formUuid } });
+        } else if (fundingProgrammeUuid != null) {
+          await fundingProgrammeExportAll.downloadFile({ pathParams: { uuid: fundingProgrammeUuid } });
         }
-      };
-
-      if (formUuid != null) {
-        return exporter(async () => {
-          const { fileName, blob } = await formSubmissionsExportCsv.fetchBlob({ pathParams: { uuid: formUuid } });
-          return { fileName, response: blob };
-        });
-      } else if (fundingProgrammeUuid != null) {
-        return exporter(async () => {
-          const { data, loadFailure } = await downloadApplicationExport(fundingProgrammeUuid);
-          if (loadFailure != null) {
-            throw loadFailure;
-          }
-          return { response: data?.url as string };
-        });
+      } catch (err: any) {
+        setError(err.message);
+        notify(err.message ?? "Export Error", { undoable: false, type: "error" });
+      } finally {
+        setLoading(false);
       }
 
       throw new Error("Incorrect Props supplied to export applications");

--- a/src/admin/modules/disturbanceReport/DisturbanceReportList.tsx
+++ b/src/admin/modules/disturbanceReport/DisturbanceReportList.tsx
@@ -26,7 +26,6 @@ import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import { getChangeRequestStatusOptions, getReportStatusOptions } from "@/constants/options/status";
 import { entityExportAll } from "@/generated/v3/entityService/entityServiceComponents";
 import { DisturbanceReportLightDto } from "@/generated/v3/entityService/entityServiceSchemas";
-import { downloadFileBlob } from "@/utils/network";
 import { optionToChoices } from "@/utils/options";
 
 import Intensity, { IntensityEnum } from "./components/Intensity";
@@ -88,8 +87,7 @@ export const DisturbanceReportList: FC = () => {
   const handleExport = async () => {
     setExporting(true);
     try {
-      const { fileName, blob } = await entityExportAll.fetchBlob({ pathParams: { entity: "disturbanceReports" } });
-      await downloadFileBlob(blob, fileName ?? "DisturbanceReports.csv");
+      await entityExportAll.downloadFile({ pathParams: { entity: "disturbanceReports" } });
     } catch (e) {
       throw v3ErrorForRA("Failed to fetch disturbance report exports", e);
     } finally {

--- a/src/admin/modules/srpReport/SRPReportList.tsx
+++ b/src/admin/modules/srpReport/SRPReportList.tsx
@@ -26,7 +26,6 @@ import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import { getChangeRequestStatusOptions, getReportStatusOptions } from "@/constants/options/status";
 import { entityExportAll } from "@/generated/v3/entityService/entityServiceComponents";
 import { SrpReportLightDto } from "@/generated/v3/entityService/entityServiceSchemas";
-import { downloadFileBlob } from "@/utils/network";
 
 const SRPReportDataGrid: FC = () => {
   const tableMenu = [
@@ -103,8 +102,7 @@ export const SRPReportList: FC = () => {
   const handleExport = async () => {
     setExporting(true);
     try {
-      const { fileName, blob } = await entityExportAll.fetchBlob({ pathParams: { entity: "srpReports" } });
-      await downloadFileBlob(blob, fileName ?? "SRPReports.csv");
+      await entityExportAll.downloadFile({ pathParams: { entity: "srpReports" } });
     } catch (e) {
       throw v3ErrorForRA("Failed to fetch SRP report exports", e);
     } finally {

--- a/src/components/elements/ImageGallery/ImageGalleryItem.tsx
+++ b/src/components/elements/ImageGallery/ImageGalleryItem.tsx
@@ -8,10 +8,11 @@ import Text from "@/components/elements/Text/Text";
 import Icon, { IconNames } from "@/components/extensive/Icon/Icon";
 import { ModalId } from "@/components/extensive/Modal/ModalConst";
 import ModalImageDetails from "@/components/extensive/Modal/ModalImageDetails";
-import { downloadImage, updateMedia } from "@/connections/Media";
+import { updateMedia } from "@/connections/Media";
 import { useLoading } from "@/context/loaderAdmin.provider";
 import { useModalContext } from "@/context/modal.provider";
 import { useNotificationContext } from "@/context/notification.provider";
+import { exportImage } from "@/generated/v3/entityService/entityServiceComponents";
 import { MediaDto } from "@/generated/v3/entityService/entityServiceSchemas";
 import { useGetReadableEntityName } from "@/hooks/entity/useGetReadableEntityName";
 import { EntityName } from "@/types/common";
@@ -86,17 +87,7 @@ const ImageGalleryItem: FC<ImageGalleryItemProps> = ({
   const handleDownload = useCallback(async (): Promise<void> => {
     showLoader();
     try {
-      const { fileName, blob } = await downloadImage(data.uuid);
-      const url = window.URL.createObjectURL(blob);
-
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = link.download = data?.fileName ?? fileName ?? "image.jpg";
-      document.body.appendChild(link);
-      link.click();
-
-      link.remove();
-      window.URL.revokeObjectURL(url);
+      await exportImage.downloadFile({ pathParams: { uuid: data.uuid } }, data?.fileName);
       hideLoader();
       openNotification("success", t("Success!"), t("Image downloaded successfully"));
     } catch (error) {

--- a/src/components/elements/Map-mapbox/hooks/useMapMedia.tsx
+++ b/src/components/elements/Map-mapbox/hooks/useMapMedia.tsx
@@ -3,7 +3,8 @@ import React, { MutableRefObject, useEffect } from "react";
 
 import { ModalId } from "@/components/extensive/Modal/ModalConst";
 import ModalImageDetails from "@/components/extensive/Modal/ModalImageDetails";
-import { deleteMedia, downloadImage, updateMedia } from "@/connections/Media";
+import { deleteMedia, updateMedia } from "@/connections/Media";
+import { exportImage } from "@/generated/v3/entityService/entityServiceComponents";
 import { MediaDto } from "@/generated/v3/entityService/entityServiceSchemas";
 import Log from "@/utils/log";
 
@@ -80,18 +81,10 @@ export function useMapMedia({
       }
     };
 
-    const handleDownload = async (uuid: string, file_name: string): Promise<void> => {
+    const handleDownload = async (uuid: string, fileName: string): Promise<void> => {
       showLoader();
       try {
-        const { fileName, blob } = await downloadImage(uuid);
-        const url = window.URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.href = url;
-        link.download = file_name ?? fileName ?? "image.jpg";
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        window.URL.revokeObjectURL(url);
+        await exportImage.downloadFile({ pathParams: { uuid } }, fileName);
         openNotification("success", t("Success!"), t("Image downloaded successfully"));
       } catch (error) {
         Log.error("Download error:", error);

--- a/src/connections/Entity.ts
+++ b/src/connections/Entity.ts
@@ -1,16 +1,12 @@
 import { EnabledProp, FilterProp, IdProp, SideloadsProp, v3Resource } from "@/connections/util/apiConnectionFactory";
 import { connectionHook, connectionLoader, creationHook } from "@/connections/util/connectionShortcuts";
 import { deleterAsync } from "@/connections/util/resourceDeleter";
-import { Framework } from "@/context/framework.provider";
 import {
   entityCreate,
   EntityCreateError,
   EntityCreateResponse,
   EntityCreateVariables,
   entityDelete,
-  entityExport,
-  entityExportAll,
-  EntityExportAllQueryParams,
   entityGet,
   EntityGetPathParams,
   entityIndex,
@@ -24,7 +20,6 @@ import {
   DisturbanceReportFullDto,
   DisturbanceReportLightDto,
   DisturbanceReportUpdateData,
-  FileDownloadDto,
   FinancialReportFullDto,
   FinancialReportLightDto,
   FinancialReportUpdateData,
@@ -56,7 +51,6 @@ import {
 import ApiSlice from "@/store/apiSlice";
 import { EntityName } from "@/types/common";
 import { Filter, PaginatedConnectionProps } from "@/types/connection";
-import { loadConnection } from "@/utils/loadConnection";
 
 export type ReportFullDto =
   | DisturbanceReportFullDto
@@ -319,36 +313,4 @@ export const useFullEntity = (entity: SupportedEntity, id: string) => {
     default:
       throw new Error(`Unsupported entity type [${entity}]`);
   }
-};
-
-type ExportAllProps = {
-  entity: SupportedEntity;
-  framework: Framework;
-};
-const exportAllConnection = v3Resource("fileDownloads", entityExportAll)
-  .singleByCustomId<FileDownloadDto, ExportAllProps>(
-    ({ entity, framework }) =>
-      entity == null || framework == null
-        ? undefined
-        : {
-            pathParams: { entity },
-            queryParams: { frameworkKey: framework as EntityExportAllQueryParams["frameworkKey"] }
-          },
-    ({ entity }) => `${entity}Export`
-  )
-  .buildConnection();
-export const downloadEntityAllCsv = async (entity: SupportedEntity, framework: Framework) => {
-  ApiSlice.pruneCache("fileDownloads", [`${entity}Export`]);
-  return await loadConnection(exportAllConnection, { entity, framework });
-};
-
-const exportProjectConnection = v3Resource("fileDownloads", entityExport)
-  .singleByCustomId<FileDownloadDto, { uuid: string }>(
-    ({ uuid }) => (uuid == null ? undefined : { pathParams: { entity: "projects", uuid } }),
-    ({ uuid }) => `projectExport|${uuid}`
-  )
-  .buildConnection();
-export const downloadProjectZip = async (uuid: string) => {
-  ApiSlice.pruneCache("fileDownloads", [`projectExport|${uuid}`]);
-  return await loadConnection(exportProjectConnection, { uuid });
 };

--- a/src/connections/FundingProgramme.ts
+++ b/src/connections/FundingProgramme.ts
@@ -5,15 +5,11 @@ import { resourceCreator, resourceUpdater } from "@/connections/util/resourceMut
 import {
   fundingProgrammeCreate,
   fundingProgrammeDelete,
-  fundingProgrammeExportAll,
-  FundingProgrammeExportAllPathParams,
   fundingProgrammeGet,
   fundingProgrammesIndex,
   fundingProgrammeUpdate
 } from "@/generated/v3/entityService/entityServiceComponents";
-import { FileDownloadDto, FundingProgrammeDto } from "@/generated/v3/entityService/entityServiceSchemas";
-import ApiSlice from "@/store/apiSlice";
-import { loadConnection } from "@/utils/loadConnection";
+import { FundingProgrammeDto } from "@/generated/v3/entityService/entityServiceSchemas";
 
 const fundingProgrammeConnection = v3Resource("fundingProgrammes", fundingProgrammeGet)
   .singleResource<FundingProgrammeDto>(({ id }) => (id == null ? undefined : { pathParams: { uuid: id } }))
@@ -41,14 +37,3 @@ const createFundingProgrammeConnection = v3Resource("fundingProgrammes", funding
   .buildConnection();
 export const createFundingProgramme = resourceCreator(createFundingProgrammeConnection);
 export const updateFundingProgramme = resourceUpdater(fundingProgrammeConnection);
-
-const exportAllConnection = v3Resource("fileDownloads", fundingProgrammeExportAll)
-  .singleByCustomId<FileDownloadDto, FundingProgrammeExportAllPathParams>(
-    pathParams => ({ pathParams }),
-    ({ uuid }) => `fundingProgrammeExport|${uuid}`
-  )
-  .buildConnection();
-export const downloadApplicationExport = async (uuid: string) => {
-  ApiSlice.pruneCache("fileDownloads", [`fundingProgrammeExport|${uuid}`]);
-  return await loadConnection(exportAllConnection, { uuid });
-};

--- a/src/connections/Media.ts
+++ b/src/connections/Media.ts
@@ -2,7 +2,6 @@ import exifr from "exifr";
 
 import { deleterAsync } from "@/connections/util/resourceDeleter";
 import {
-  exportImage,
   getMedia,
   mediaDelete,
   mediaUpdate,
@@ -31,8 +30,6 @@ export const updateMedia = resourceUpdater(mediaConnection);
 export const useMedia = connectionHook(mediaConnection);
 
 export const deleteMedia = deleterAsync("media", mediaDelete, uuid => ({ pathParams: { uuid: uuid } }));
-
-export const downloadImage = (uuid: string) => exportImage.fetchBlob({ pathParams: { uuid } });
 
 export const prepareFileForUpload = async (
   file: File,

--- a/src/generated/v3/utils.ts
+++ b/src/generated/v3/utils.ts
@@ -19,7 +19,7 @@ import {
 import { Dictionary, isObject } from "lodash";
 import qs, { ParsedQs } from "qs";
 import { getAccessToken, removeAccessToken } from "@/admin/apiProvider/utils/token";
-import { delayedJobsFind } from "@/generated/v3/jobService/jobServiceComponents";
+import { downloadFileBlob, downloadFileUrl } from "@/utils/network";
 
 export type ErrorPayload = { statusCode: number; message: string };
 export type ErrorWrapper<TError extends undefined | { payload: ErrorPayload }> =
@@ -173,12 +173,16 @@ export class V3ApiEndpoint<
   }
 
   /**
-   * Fetch the raw payload from this endpoint. This is meant to be used for non-JSON endpoints
-   * *only*, and should only be needed for downloading blobs for saving on the client filesystem
-   * (like a CSV download).
+   * A utility to get a file from a backend endpoint. These endpoints are expected to generate
+   * either a non-JSON content type that will be downloaded as a blob or a single FileDownloadDto in
+   * eventual response. Supports delayed job handling.
+   *
+   * A default file name may be provided, but in most cases it should not be necessary. In the case
+   * of a FileDownloadDto, the file's name at its URL is used, and in the case of a blob download, the
+   * file name is typically provided by the server in the Content-Disposition header.
    */
-  async fetchBlob(variables: TVariables, headers?: THeaders): Promise<{ fileName?: string; blob: Blob }> {
-    const { url, body, requestHeaders } = this.prepareRequest(variables, headers);
+  async downloadFile(variables: TVariables, defaultFileName?: string) {
+    const { url, body, requestHeaders } = this.prepareRequest(variables);
     const response = await fetch(url, { method: this.method, body, headers: requestHeaders });
 
     if (!response.ok) {
@@ -186,9 +190,32 @@ export class V3ApiEndpoint<
     }
 
     const type = response.headers.get("content-type");
-    if (type?.includes("json")) {
-      // this API integration only supports JSON type responses.
-      throw new Error(`fetchBlob is only to be used for non-JSON endpoints [${type}]`);
+    if (type == null) {
+      throw new Error("No content type found");
+    }
+
+    if (type.includes("json")) {
+      let responsePayload = await response.json();
+      if (isPendingError(responsePayload)) throw responsePayload;
+
+      if (
+        !url.includes("jobs/v3/delayedJobs") &&
+        responsePayload?.data?.attributes?.uuid != null &&
+        responsePayload?.data?.type == "delayedJobs"
+      ) {
+        responsePayload = await processDelayedJob<JsonApiResponse>(responsePayload.data.attributes.uuid);
+      }
+
+      const { data } = responsePayload as JsonApiResponse;
+      if (data == null || Array.isArray(data) || data.type !== "fileDownloads") {
+        throw new Error("Unexpected response format for file download");
+      }
+
+      // avoid importing the FileDownloadDto due to circular dependency
+      const downloadUrl = data.attributes.url as string;
+      const fileName = downloadUrl.split("/").pop();
+      downloadFileUrl(downloadUrl, fileName ?? defaultFileName);
+      return;
     }
 
     const disposition = response.headers.get("content-disposition");
@@ -197,7 +224,7 @@ export class V3ApiEndpoint<
         ? undefined
         : decodeURIComponent(disposition.split("filename=")[1].split(";")[0].replace(/['"]/g, ""));
 
-    return { fileName, blob: await response.blob() };
+    await downloadFileBlob(await response.blob(), fileName ?? defaultFileName);
   }
 
   isFetchingSelector(variables: Omit<RequestVariables, "body">) {

--- a/src/hooks/entity/useGetExportEntityHandler.ts
+++ b/src/hooks/entity/useGetExportEntityHandler.ts
@@ -1,13 +1,13 @@
 import { useT } from "@transifex/react";
+import { startCase } from "lodash";
 import { useCallback, useState } from "react";
 
-import { downloadProjectZip, SupportedEntity } from "@/connections/Entity";
+import { SupportedEntity } from "@/connections/Entity";
 import { ToastType, useToastContext } from "@/context/toast.provider";
 import { entityExport } from "@/generated/v3/entityService/entityServiceComponents";
-import { v3EntityName } from "@/helpers/entity";
+import { singularEntityName, v3EntityName } from "@/helpers/entity";
 import { EntityName } from "@/types/common";
 import Log from "@/utils/log";
-import { downloadFileBlob, downloadFileUrl } from "@/utils/network";
 
 /**
  * To get entity export handler
@@ -20,28 +20,13 @@ export const useGetExportEntityHandler = (entity: EntityName, uuid: string) => {
   const handleExport = useCallback(async () => {
     setLoading(true);
 
-    const reportError = (error?: any) => {
-      Log.error("Error exporting entity", error);
-      openToast(t("Something went wrong!"), ToastType.ERROR);
-    };
-
     try {
       const entityName = v3EntityName(entity) as SupportedEntity;
-      if (entityName === "projects") {
-        const { data, loadFailure } = await downloadProjectZip(uuid);
-        if (loadFailure != null) {
-          reportError(loadFailure);
-        } else {
-          downloadFileUrl(data?.url as string);
-          openToast(t(`${entity} successfully exported`, { entity }));
-        }
-      } else {
-        const { fileName, blob } = await entityExport.fetchBlob({ pathParams: { entity: entityName, uuid } });
-        await downloadFileBlob(blob, fileName as string);
-        openToast(t(`${entity} successfully exported`, { entity }));
-      }
+      await entityExport.downloadFile({ pathParams: { entity: entityName, uuid } });
+      openToast(t(`${startCase(singularEntityName(entity))} successfully exported`));
     } catch (error) {
-      reportError(error);
+      Log.error("Error exporting entity", error);
+      openToast(t("Something went wrong!"), ToastType.ERROR);
     } finally {
       setLoading(false);
     }

--- a/src/pages/applications/components/ApplicationHeader.tsx
+++ b/src/pages/applications/components/ApplicationHeader.tsx
@@ -5,7 +5,6 @@ import Button from "@/components/elements/Button/Button";
 import PageHeader from "@/components/extensive/PageElements/Header/PageHeader";
 import { applicationExportGet } from "@/generated/v3/entityService/entityServiceComponents";
 import Log from "@/utils/log";
-import { downloadFileBlob } from "@/utils/network";
 
 interface ApplicationHeaderProps {
   name: string;
@@ -17,8 +16,7 @@ const ApplicationHeader: FC<ApplicationHeaderProps> = ({ name, uuid }) => {
 
   const handleExport = useCallback(async () => {
     try {
-      const { fileName, blob } = await applicationExportGet.fetchBlob({ pathParams: { uuid } });
-      return downloadFileBlob(blob, fileName ?? "Application.csv");
+      await applicationExportGet.downloadFile({ pathParams: { uuid } });
     } catch (err) {
       Log.error("Failed to fetch applications exports", err);
     }

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -21,12 +21,12 @@ export const downloadFileUrl = (url: string, fileName?: string) => {
  * @param blob File contents to download
  * @param fileName File name to assign to download.
  */
-export const downloadFileBlob = async (blob: Blob, fileName: string) => {
+export const downloadFileBlob = async (blob: Blob, fileName?: string) => {
   try {
     const url = window.URL.createObjectURL(new Blob([blob]));
     const link = document.createElement("a");
     link.href = url;
-    link.setAttribute("download", fileName);
+    if (fileName != null) link.download = fileName;
     link.click();
   } catch (err) {
     Log.error("Failed to download blob", fileName, err);


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-2896

We now have several endpoints in the BE that can return either a streamed file blob or a FileDownloadDto (sometimes through a delayed job) pointing to a cached file in S3.

In the previous implementation, the FE code had to know what to expect from the BE based on what the BE was supposed to be generating for its params, which is very inflexible and fragile. With downloadFile, we instead rely on the content type of the response to decide whether to a) download a blob, or b) process the JSON response (including delayed job processing) to find a file URL to download instead.